### PR TITLE
SyncPeriod and 16dot16 duration conversions

### DIFF
--- a/mdbx/duration.go
+++ b/mdbx/duration.go
@@ -1,0 +1,22 @@
+package mdbx
+
+import "time"
+
+/*
+#include <stdint.h>
+*/
+import "C"
+
+type Duration16dot16 uint64
+
+func (d Duration16dot16) ToDuration() time.Duration {
+	return time.Duration(d) * (time.Second / 65536)
+}
+
+func NewDuration16dot16(duration time.Duration) Duration16dot16 {
+	return Duration16dot16(duration / (time.Second / 65536))
+}
+
+func toDuration(seconds16dot16 C.uint32_t) time.Duration {
+	return Duration16dot16(seconds16dot16).ToDuration()
+}

--- a/mdbx/duration_test.go
+++ b/mdbx/duration_test.go
@@ -1,0 +1,36 @@
+package mdbx
+
+import (
+	"testing"
+	"time"
+)
+
+func assertEqualDuration(t *testing.T, actual time.Duration, expected time.Duration) {
+	diff := actual.Nanoseconds() - expected.Nanoseconds()
+	threshold := int64(time.Millisecond)
+	if (diff > threshold) || (diff < -threshold) {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertEqual16dot16(t *testing.T, actual Duration16dot16, expected Duration16dot16) {
+	diff := int64(actual) - int64(expected)
+	threshold := int64(66)
+	if (diff > threshold) || (diff < -threshold) {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func TestDurationWithDuration(t *testing.T) {
+	for i := 0; i <= 1000; i++ {
+		expected := time.Duration(i) * time.Second
+		assertEqualDuration(t, NewDuration16dot16(expected).ToDuration(), expected)
+	}
+}
+
+func TestDurationWith16dot16(t *testing.T) {
+	for i := 0; i <= 1000; i++ {
+		expected := Duration16dot16(i * 65536)
+		assertEqual16dot16(t, NewDuration16dot16(expected.ToDuration()), expected)
+	}
+}

--- a/mdbx/env.go
+++ b/mdbx/env.go
@@ -468,6 +468,17 @@ func (env *Env) GetOption(option uint) (uint64, error) {
 	return uint64(res), operrno("mdbx_env_get_option", ret)
 }
 
+func (env *Env) SetSyncPeriod(value time.Duration) error {
+	ret := C.mdbx_env_set_syncperiod(env._env, C.uint(NewDuration16dot16(value)))
+	return operrno("mdbx_env_set_syncperiod", ret)
+}
+
+func (env *Env) GetSyncPeriod() (time.Duration, error) {
+	var res C.uint
+	ret := C.mdbx_env_get_syncperiod(env._env, &res)
+	return Duration16dot16(res).ToDuration(), operrno("mdbx_env_get_syncperiod", ret)
+}
+
 func (env *Env) SetGeometry(sizeLower int, sizeNow int, sizeUpper int, growthStep int, shrinkThreshold int, pageSize int) error {
 	ret := C.mdbx_env_set_geometry(env._env,
 		C.intptr_t(sizeLower),

--- a/mdbx/txn.go
+++ b/mdbx/txn.go
@@ -208,10 +208,6 @@ type CommitLatency struct {
 	Whole       time.Duration
 }
 
-func toDuration(seconds16dot16 C.uint32_t) time.Duration {
-	return time.Duration((uint64(1000000000)*uint64(seconds16dot16) + 32768) >> 16)
-}
-
 func (txn *Txn) commit() (CommitLatency, error) {
 	var _stat C.MDBX_commit_latency
 	ret := C.mdbx_txn_commit_ex(txn._txn, &_stat)

--- a/mdbx/txn_test.go
+++ b/mdbx/txn_test.go
@@ -1266,13 +1266,3 @@ func openDBI(env *Env, key string, flags uint) (DBI, error) {
 	}
 	return db, nil
 }
-
-func TestNameToNano(t *testing.T) {
-	if toDuration(65536).Milliseconds() != 1_000 {
-		t.Error("unexpected result")
-	}
-
-	if toDuration(65536*1_000).Milliseconds() != 1_000*1_000 {
-		t.Error("unexpected result")
-	}
-}


### PR DESCRIPTION
Although the old method with bit shifts is somewhat more precise, I've decided to simplify it. The simple method of conversion is precise enough for our purposes. I've added the tests to confirm this.