### PR TITLE
added readers metrics & helpers

### DIFF
--- a/mdbx/mdbxgo.c
+++ b/mdbx/mdbxgo.c
@@ -27,11 +27,11 @@ uint64_t mdbxgo_tid_to_u64(mdbx_tid_t tid) {
 }
 
 uint64_t mdbxgo_tid_txn_parked(void) {
-    return (uint64_t)(uintptr_t)UINT64_MAX;
+    return mdbxgo_tid_to_u64((mdbx_tid_t)(uintptr_t)UINT64_MAX);
 }
 
 uint64_t mdbxgo_tid_txn_ousted(void) {
-    return (uint64_t)(uintptr_t)(UINT64_MAX - 1);
+    return mdbxgo_tid_to_u64((mdbx_tid_t)(uintptr_t)(UINT64_MAX - 1));
 }
 
 int mdbxgo_reader_list_proxy(void *ctx, int num, int slot, mdbx_pid_t pid, mdbx_tid_t thread, uint64_t txnid,

--- a/mdbx/mdbxgo.c
+++ b/mdbx/mdbxgo.c
@@ -207,10 +207,11 @@ mdbxgo_commit_result mdbxgo_txn_commit_ex(MDBX_txn *txn) {
 
 mdbxgo_gc_info_result mdbxgo_gc_info(MDBX_txn *txn) {
     mdbxgo_gc_info_result r = {0};
-    MDBX_gc_info_t info;
+    MDBX_gc_info_t info = {0};
     r.err = mdbx_gc_info(txn, &info, sizeof(info), NULL, NULL);
     if (r.err == MDBX_NOTFOUND) {
         r.err = MDBX_SUCCESS;
+        return r;
     }
     if (r.err == MDBX_SUCCESS) {
         r.pages_allocated = info.pages_allocated;

--- a/mdbx/mdbxgo.c
+++ b/mdbx/mdbxgo.c
@@ -22,13 +22,29 @@ int mdbxgo_msg_func_proxy(const char *msg, void *ctx) {
     return mdbxgoMDBMsgFuncBridge(s, (size_t)ctx);
 }
 
-// int mdbxgo_reader_list(MDBX_env *env, size_t ctx) {
-//     // list readers using a static proxy function that does dynamic dispatch on
-//     // ctx.
-//	if (ctx)
-//		return mdbx_reader_list(env, &mdbxgo_msg_func_proxy, (void *)ctx);
-//	return mdbx_reader_list(env, 0, (void *)ctx);
-// }
+uint64_t mdbxgo_tid_to_u64(mdbx_tid_t tid) {
+    return (uint64_t)(uintptr_t)tid;
+}
+
+uint64_t mdbxgo_tid_txn_parked(void) {
+    return (uint64_t)(uintptr_t)UINT64_MAX;
+}
+
+uint64_t mdbxgo_tid_txn_ousted(void) {
+    return (uint64_t)(uintptr_t)(UINT64_MAX - 1);
+}
+
+int mdbxgo_reader_list_proxy(void *ctx, int num, int slot, mdbx_pid_t pid, mdbx_tid_t thread, uint64_t txnid,
+                             uint64_t lag, size_t bytes_used, size_t bytes_retained) {
+    return mdbxgoMDBReaderListBridge((size_t)ctx, num, slot, pid, mdbxgo_tid_to_u64(thread), txnid, lag, bytes_used,
+                                     bytes_retained);
+}
+
+int mdbxgo_reader_list(MDBX_env *env, size_t ctx) {
+    // List readers using a static proxy function that does dynamic dispatch on
+    // ctx in Go without passing Go pointers through C.
+    return mdbx_reader_list(env, &mdbxgo_reader_list_proxy, (void *)ctx);
+}
 
 int mdbxgo_del(MDBX_txn *txn, MDBX_dbi dbi, char *kdata, size_t kn, char *vdata, size_t vn) {
     MDBX_val key, val;
@@ -186,6 +202,26 @@ mdbxgo_uint_result mdbxgo_dbi_open_ex(MDBX_txn *txn, const char *name, MDBX_db_f
 mdbxgo_commit_result mdbxgo_txn_commit_ex(MDBX_txn *txn) {
     mdbxgo_commit_result r = {0};
     r.err = mdbx_txn_commit_ex(txn, &r.lat);
+    return r;
+}
+
+mdbxgo_gc_info_result mdbxgo_gc_info(MDBX_txn *txn) {
+    mdbxgo_gc_info_result r = {0};
+    MDBX_gc_info_t info;
+    r.err = mdbx_gc_info(txn, &info, sizeof(info), NULL, NULL);
+    if (r.err == MDBX_NOTFOUND) {
+        r.err = MDBX_SUCCESS;
+    }
+    if (r.err == MDBX_SUCCESS) {
+        r.pages_allocated = info.pages_allocated;
+        r.pages_backed = info.pages_backed;
+        r.pages_total = info.pages_total;
+        r.pages_gc = info.pages_gc;
+        r.pages_reclaimable = info.gc_reclaimable.pages;
+        r.pages_retained = (info.pages_gc > info.gc_reclaimable.pages) ? info.pages_gc - info.gc_reclaimable.pages : 0;
+        r.max_reader_lag = info.max_reader_lag;
+        r.max_retained_pages = info.max_retained_pages;
+    }
     return r;
 }
 

--- a/mdbx/mdbxgo.h
+++ b/mdbx/mdbxgo.h
@@ -30,11 +30,14 @@ int mdbxgo_cursor_putmulti(MDBX_cursor *cur, char *kdata, size_t kn, char *vdata
  * */
 typedef struct { const char *p; } mdbxgo_ConstCString;
 
-/* mdbxgo_reader_list is a proxy for mdb_reader_list that uses a special
- * mdb_msg_func proxy function to relay messages over the
- * mdbxgo_reader_list_bridge external Go func.
+/* mdbxgo_reader_list is a proxy for mdbx_reader_list that uses a special
+ * callback proxy function to relay structured reader records over the
+ * mdbxgoMDBReaderListBridge external Go func.
  * */
 int mdbxgo_reader_list(MDBX_env *env, size_t ctx);
+uint64_t mdbxgo_tid_to_u64(mdbx_tid_t tid);
+uint64_t mdbxgo_tid_txn_parked(void);
+uint64_t mdbxgo_tid_txn_ousted(void);
 
 int mdbxgo_cmp(MDBX_txn *txn, MDBX_dbi dbi, char *adata, size_t an, char *bdata, size_t bn);
 int mdbxgo_dcmp(MDBX_txn *txn, MDBX_dbi dbi, char *adata, size_t an, char *bdata, size_t bn);
@@ -66,6 +69,19 @@ mdbxgo_commit_result     mdbxgo_txn_commit_ex(MDBX_txn *txn);
 typedef struct { int err; char *kbase; size_t klen; char *vbase; size_t vlen; } mdbxgo_val_result;
 mdbxgo_val_result        mdbxgo_cursor_get_empty(MDBX_cursor *cur, MDBX_cursor_op op);
 mdbxgo_val_result        mdbxgo_cursor_get_val(MDBX_cursor *cur, char *kdata, size_t kn, char *vdata, size_t vn, MDBX_cursor_op op);
+
+typedef struct {
+    int err;
+    uint64_t pages_allocated;
+    uint64_t pages_backed;
+    uint64_t pages_total;
+    uint64_t pages_gc;
+    uint64_t pages_reclaimable;
+    uint64_t pages_retained;
+    uint64_t max_reader_lag;
+    uint64_t max_retained_pages;
+} mdbxgo_gc_info_result;
+mdbxgo_gc_info_result    mdbxgo_gc_info(MDBX_txn *txn);
 
 #ifndef _WIN32
 mdbxgo_int_result        mdbxgo_env_get_fd(MDBX_env *env);

--- a/mdbx/msgfunc.go
+++ b/mdbx/msgfunc.go
@@ -26,6 +26,35 @@ func mdbxgoMDBMsgFuncBridge(cmsg C.mdbxgo_ConstCString, _ctx C.size_t) C.int {
 	return 0
 }
 
+// mdbxgoMDBReaderListBridge provides a static C function for handling
+// MDBX_reader_list_func callbacks.  It performs type conversion and dynamic
+// dispatch to a callback provided to Env.ReaderList.  Any error returned by the
+// callback is cached and MDBX_RESULT_TRUE is returned to terminate the
+// iteration.
+//
+//export mdbxgoMDBReaderListBridge
+func mdbxgoMDBReaderListBridge(_ctx C.size_t, num C.int, slot C.int, pid C.mdbx_pid_t, thread C.uint64_t, txnid C.uint64_t, lag C.uint64_t, bytesUsed C.size_t, bytesRetained C.size_t) C.int {
+	ctx := readerctx(_ctx).get()
+	info := ReaderInfo{
+		Num:           int(num),
+		Slot:          int(slot),
+		PID:           int(pid),
+		TID:           uint64(thread),
+		TxID:          uint64(txnid),
+		Lag:           uint64(lag),
+		BytesUsed:     uint64(bytesUsed),
+		BytesRetained: uint64(bytesRetained),
+	}
+	info.Parked = info.TID == readerTIDTxnParked
+	info.Ousted = info.TID == readerTIDTxnOusted
+	err := ctx.fn(info)
+	if err != nil {
+		ctx.err = err
+		return C.MDBX_RESULT_TRUE
+	}
+	return C.MDBX_RESULT_FALSE
+}
+
 type msgfunc func(string) error
 
 // msgctx is the type used for context pointers passed to mdb_reader_list.  A
@@ -79,5 +108,49 @@ func (ctx msgctx) get() *_msgctx {
 	msgctxmlock.RLock()
 	_ctx := msgctxm[ctx]
 	msgctxmlock.RUnlock()
+	return _ctx
+}
+
+type readerfunc func(ReaderInfo) error
+
+// readerctx is the type used for context pointers passed to mdbx_reader_list.
+// It keeps Go pointers out of C memory by storing callback state in a Go map
+// and passing only an integer handle through libmdbx.
+type readerctx uintptr
+type _readerctx struct {
+	fn  readerfunc
+	err error
+}
+
+var readerctxn uint32
+var readerctxm = map[readerctx]*_readerctx{}
+var readerctxmlock sync.RWMutex
+
+func newReaderFunc(fn readerfunc) (ctx readerctx, done func()) {
+	ctx = readerctx(atomic.AddUint32(&readerctxn, 1))
+	ctx.register(fn)
+	return ctx, ctx.deregister
+}
+
+func (ctx readerctx) register(fn readerfunc) {
+	readerctxmlock.Lock()
+	if _, ok := readerctxm[ctx]; ok {
+		readerctxmlock.Unlock()
+		panic("readerfunc conflict")
+	}
+	readerctxm[ctx] = &_readerctx{fn: fn}
+	readerctxmlock.Unlock()
+}
+
+func (ctx readerctx) deregister() {
+	readerctxmlock.Lock()
+	delete(readerctxm, ctx)
+	readerctxmlock.Unlock()
+}
+
+func (ctx readerctx) get() *_readerctx {
+	readerctxmlock.RLock()
+	_ctx := readerctxm[ctx]
+	readerctxmlock.RUnlock()
 	return _ctx
 }

--- a/mdbx/msgfunc.go
+++ b/mdbx/msgfunc.go
@@ -5,6 +5,7 @@ package mdbx
 */
 import "C"
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 )
@@ -33,8 +34,15 @@ func mdbxgoMDBMsgFuncBridge(cmsg C.mdbxgo_ConstCString, _ctx C.size_t) C.int {
 // iteration.
 //
 //export mdbxgoMDBReaderListBridge
-func mdbxgoMDBReaderListBridge(_ctx C.size_t, num C.int, slot C.int, pid C.mdbx_pid_t, thread C.uint64_t, txnid C.uint64_t, lag C.uint64_t, bytesUsed C.size_t, bytesRetained C.size_t) C.int {
+func mdbxgoMDBReaderListBridge(_ctx C.size_t, num C.int, slot C.int, pid C.mdbx_pid_t, thread C.uint64_t, txnid C.uint64_t, lag C.uint64_t, bytesUsed C.size_t, bytesRetained C.size_t) (rc C.int) {
 	ctx := readerctx(_ctx).get()
+	defer func() {
+		if r := recover(); r != nil {
+			ctx.err = fmt.Errorf("mdbx: panic in ReaderList callback: %v", r)
+			rc = C.MDBX_RESULT_TRUE
+		}
+	}()
+
 	info := ReaderInfo{
 		Num:           int(num),
 		Slot:          int(slot),

--- a/mdbx/reader.go
+++ b/mdbx/reader.go
@@ -1,0 +1,107 @@
+package mdbx
+
+/*
+#include "mdbxgo.h"
+*/
+import "C"
+
+import "errors"
+
+var errNilReaderListFunc = errors.New("mdbx: nil ReaderList callback")
+
+var (
+	readerTIDTxnParked = uint64(C.mdbxgo_tid_txn_parked())
+	readerTIDTxnOusted = uint64(C.mdbxgo_tid_txn_ousted())
+)
+
+// ReaderTIDTxnParked is the raw thread marker used by libmdbx for parked
+// read transactions. Prefer ReaderInfo.Parked for application logic.
+var ReaderTIDTxnParked = readerTIDTxnParked
+
+// ReaderTIDTxnOusted is the raw thread marker used by libmdbx for ousted
+// read transactions. Prefer ReaderInfo.Ousted for application logic.
+var ReaderTIDTxnOusted = readerTIDTxnOusted
+
+// ReaderInfo describes one entry in the MDBX reader lock table.
+type ReaderInfo struct {
+	Num           int
+	Slot          int
+	PID           int
+	TID           uint64
+	TxID          uint64
+	Lag           uint64
+	BytesUsed     uint64
+	BytesRetained uint64
+	Parked        bool
+	Ousted        bool
+}
+
+// ReaderStats summarizes MDBX reader lock table state for metrics and
+// monitoring. Collecting it may require scanning the reader lock table.
+type ReaderStats struct {
+	Count            uint64
+	OldestTxID       uint64
+	MaxLag           uint64
+	MaxBytesUsed     uint64
+	MaxBytesRetained uint64
+	SumBytesRetained uint64
+	Parked           uint64
+	Ousted           uint64
+}
+
+// ReaderList enumerates the MDBX reader lock table as structured records.
+//
+// BytesRetained is the approximate amount of data prevented from reuse by the
+// reader's MVCC snapshot.
+func (env *Env) ReaderList(fn func(ReaderInfo) error) error {
+	if fn == nil {
+		return errNilReaderListFunc
+	}
+	ctx, done := newReaderFunc(fn)
+	defer done()
+
+	ret := C.mdbxgo_reader_list(env._env, C.size_t(ctx))
+	if ctxerr := ctx.get().err; ctxerr != nil {
+		return ctxerr
+	}
+	return operrno("mdbx_reader_list", ret)
+}
+
+// Readers returns a snapshot of all entries in the MDBX reader lock table.
+func (env *Env) Readers() ([]ReaderInfo, error) {
+	var readers []ReaderInfo
+	err := env.ReaderList(func(info ReaderInfo) error {
+		readers = append(readers, info)
+		return nil
+	})
+	return readers, err
+}
+
+// ReaderStats returns aggregate MDBX reader metrics.
+func (env *Env) ReaderStats() (ReaderStats, error) {
+	var stats ReaderStats
+	err := env.ReaderList(func(info ReaderInfo) error {
+		stats.Count++
+		if info.TxID != 0 && (stats.OldestTxID == 0 || info.TxID < stats.OldestTxID) {
+			stats.OldestTxID = info.TxID
+		}
+		if info.Lag > stats.MaxLag {
+			stats.MaxLag = info.Lag
+		}
+		if info.BytesUsed > stats.MaxBytesUsed {
+			stats.MaxBytesUsed = info.BytesUsed
+		}
+		if info.BytesRetained > stats.MaxBytesRetained {
+			stats.MaxBytesRetained = info.BytesRetained
+		}
+		stats.SumBytesRetained += info.BytesRetained
+		if info.Parked {
+			stats.Parked++
+		}
+		if info.Ousted {
+			stats.Ousted++
+		}
+		return nil
+	})
+	return stats, err
+}

--- a/mdbx/reader_test.go
+++ b/mdbx/reader_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -57,6 +58,26 @@ func TestEnv_ReaderListCallbackError(t *testing.T) {
 		return want
 	})
 	if !errors.Is(err, want) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnv_ReaderListCallbackPanic(t *testing.T) {
+	env, _ := setupReaderInfoEnv(t)
+
+	txn, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin reader: %v", err)
+	}
+	defer txn.Abort()
+
+	err = env.ReaderList(func(ReaderInfo) error {
+		panic("stop reader list")
+	})
+	if err == nil {
+		t.Fatalf("expected panic to be converted to error")
+	}
+	if !strings.Contains(err.Error(), "stop reader list") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/mdbx/reader_test.go
+++ b/mdbx/reader_test.go
@@ -1,0 +1,217 @@
+package mdbx
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestEnv_ReaderListEmpty(t *testing.T) {
+	env, _ := setup(t)
+
+	called := false
+	if err := env.ReaderList(func(ReaderInfo) error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("reader list: %v", err)
+	}
+	if called {
+		t.Fatalf("unexpected reader record in empty reader table")
+	}
+}
+
+func TestEnv_ReadersIncludesOpenReadTxn(t *testing.T) {
+	env, dbi := setupReaderInfoEnv(t)
+
+	txn, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin reader: %v", err)
+	}
+	defer txn.Abort()
+	if _, err = txn.Get(dbi, []byte("key-0000")); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	readers, err := env.Readers()
+	if err != nil {
+		t.Fatalf("readers: %v", err)
+	}
+	if !hasReader(readers, txn.ID()) {
+		t.Fatalf("reader txid %d not found in %#v", txn.ID(), readers)
+	}
+}
+
+func TestEnv_ReaderListCallbackError(t *testing.T) {
+	env, _ := setupReaderInfoEnv(t)
+
+	txn, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin reader: %v", err)
+	}
+	defer txn.Abort()
+
+	want := errors.New("stop reader list")
+	err = env.ReaderList(func(ReaderInfo) error {
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnv_ReaderStatsLagAndRetained(t *testing.T) {
+	env, dbi := setupReaderInfoEnv(t)
+
+	old, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin old reader: %v", err)
+	}
+	defer old.Abort()
+	if _, err = old.Get(dbi, []byte("key-0000")); err != nil {
+		t.Fatalf("old get: %v", err)
+	}
+
+	if err = churnReaderInfoPages(env, dbi); err != nil {
+		t.Fatalf("churn pages: %v", err)
+	}
+
+	stats, err := env.ReaderStats()
+	if err != nil {
+		t.Fatalf("reader stats: %v", err)
+	}
+	if stats.Count == 0 {
+		t.Fatalf("expected at least one reader")
+	}
+	if old.ID() != 0 && stats.OldestTxID != old.ID() {
+		t.Fatalf("oldest txid = %d, want %d", stats.OldestTxID, old.ID())
+	}
+	if stats.MaxLag == 0 {
+		t.Fatalf("expected reader lag after write commit, got %#v", stats)
+	}
+	if stats.MaxBytesRetained == 0 || stats.SumBytesRetained == 0 {
+		t.Fatalf("expected retained bytes after deletes with old reader, got %#v", stats)
+	}
+}
+
+func TestEnv_ReaderListParked(t *testing.T) {
+	env, dbi := setupReaderInfoEnv(t)
+
+	txn, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin reader: %v", err)
+	}
+	defer func() {
+		_ = txn.Unpark(true)
+		txn.Abort()
+	}()
+	if _, err = txn.Get(dbi, []byte("key-0000")); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if err = txn.Park(true); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+
+	readers, err := env.Readers()
+	if err != nil {
+		t.Fatalf("readers: %v", err)
+	}
+	for _, reader := range readers {
+		if reader.Parked {
+			return
+		}
+	}
+	t.Fatalf("parked reader not found in %#v", readers)
+}
+
+func TestTxn_GCInfo(t *testing.T) {
+	env, dbi := setupReaderInfoEnv(t)
+	if err := churnReaderInfoPages(env, dbi); err != nil {
+		t.Fatalf("churn pages: %v", err)
+	}
+
+	if err := env.View(func(txn *Txn) error {
+		info, err := txn.GCInfo()
+		if err != nil {
+			return err
+		}
+		if info.PagesAllocated == 0 {
+			t.Fatalf("expected allocated pages, got %#v", info)
+		}
+		if info.PagesBacked > info.PagesTotal {
+			t.Fatalf("backed pages exceed total pages: %#v", info)
+		}
+		if info.PagesAllocated > info.PagesTotal {
+			t.Fatalf("allocated pages exceed total pages: %#v", info)
+		}
+		if info.PagesReclaimable > info.PagesGC {
+			t.Fatalf("reclaimable pages exceed GC pages: %#v", info)
+		}
+		if info.PagesRetained != info.PagesGC-info.PagesReclaimable {
+			t.Fatalf("retained pages mismatch: %#v", info)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("gc info: %v", err)
+	}
+}
+
+func setupReaderInfoEnv(t *testing.T) (*Env, DBI) {
+	t.Helper()
+	env, _ := setup(t)
+	var dbi DBI
+	err := env.Update(func(txn *Txn) error {
+		var err error
+		dbi, err = txn.OpenRoot(0)
+		if err != nil {
+			return err
+		}
+		value := make([]byte, 512)
+		for i := range value {
+			value[i] = byte(i)
+		}
+		for i := 0; i < 2048; i++ {
+			key := []byte(fmt.Sprintf("key-%04d", i))
+			if err = txn.Put(dbi, key, value, 0); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed env: %v", err)
+	}
+	return env, dbi
+}
+
+func churnReaderInfoPages(env *Env, dbi DBI) error {
+	return env.Update(func(txn *Txn) error {
+		value := make([]byte, 768)
+		for i := range value {
+			value[i] = byte(255 - i)
+		}
+		for i := 0; i < 1024; i++ {
+			key := []byte(fmt.Sprintf("key-%04d", i))
+			if err := txn.Put(dbi, key, value, 0); err != nil {
+				return err
+			}
+		}
+		for i := 1024; i < 2048; i++ {
+			key := []byte(fmt.Sprintf("key-%04d", i))
+			if err := txn.Del(dbi, key, nil); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func hasReader(readers []ReaderInfo, txid uint64) bool {
+	for _, reader := range readers {
+		if reader.PID == os.Getpid() && reader.TxID == txid {
+			return true
+		}
+	}
+	return false
+}

--- a/mdbx/txn.go
+++ b/mdbx/txn.go
@@ -558,6 +558,36 @@ type TxInfo struct {
 	Unspill uint64
 }
 
+// GCInfo describes MDBX garbage collection and page usage for a transaction.
+type GCInfo struct {
+	PagesAllocated   uint64
+	PagesBacked      uint64
+	PagesTotal       uint64
+	PagesGC          uint64
+	PagesReclaimable uint64
+	PagesRetained    uint64
+	MaxReaderLag     uint64
+	MaxRetainedPages uint64
+}
+
+// GCInfo returns garbage collection and page usage information for txn.
+func (txn *Txn) GCInfo() (*GCInfo, error) {
+	r := C.mdbxgo_gc_info(txn._txn)
+	if r.err != success {
+		return nil, operrno("mdbx_gc_info", r.err)
+	}
+	return &GCInfo{
+		PagesAllocated:   uint64(r.pages_allocated),
+		PagesBacked:      uint64(r.pages_backed),
+		PagesTotal:       uint64(r.pages_total),
+		PagesGC:          uint64(r.pages_gc),
+		PagesReclaimable: uint64(r.pages_reclaimable),
+		PagesRetained:    uint64(r.pages_retained),
+		MaxReaderLag:     uint64(r.max_reader_lag),
+		MaxRetainedPages: uint64(r.max_retained_pages),
+	}, nil
+}
+
 // scan_rlt   The boolean flag controls the scan of the read lock
 //
 //	table to provide complete information. Such scan


### PR DESCRIPTION
Implemented reader/GC observability for mdbx-go.

Changes made:

- Added structured ReaderInfo, ReaderStats, Env.ReaderList, Env.Readers, and Env.ReaderStats in reader.go.
- Added direct structured mdbx_reader_list() C callback bridging in mdbxgo.c and msgfunc.go, with callback error propagation.
- Added parked/ousted decoding via ReaderInfo.Parked and ReaderInfo.Ousted.
- Added GCInfo and Txn.GCInfo() in txn.go, deriving retained pages as pages_gc - gc_reclaimable.pages.
- Confirmed CommitLatencyGC already exposes MaxReaderLag and MaxRetainedPages.
- Added reader/GC tests in reader_test.go.
