### PR TITLE
upgrade cgosymbolizer to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/erigontech/mdbx-go
 
 go 1.24.0
 
-require github.com/ianlancetaylor/cgosymbolizer v0.0.0-20241129212102-9c50ad6b591e
+require github.com/ianlancetaylor/cgosymbolizer v0.0.0-20260504013507-f4b012c11129
 
 require golang.org/x/sys v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/ianlancetaylor/cgosymbolizer v0.0.0-20241129212102-9c50ad6b591e h1:8AnObPi8WmIgjwcidUxaREhXMSpyUJeeSrIkZTXdabw=
-github.com/ianlancetaylor/cgosymbolizer v0.0.0-20241129212102-9c50ad6b591e/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
+github.com/ianlancetaylor/cgosymbolizer v0.0.0-20260504013507-f4b012c11129 h1:ih8K3uz7eATRX/Y6HRpCNVWArsI/65kICdUEpO5Lle8=
+github.com/ianlancetaylor/cgosymbolizer v0.0.0-20260504013507-f4b012c11129/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=


### PR DESCRIPTION
## Summary
- Upgraded `github.com/ianlancetaylor/cgosymbolizer` from `v0.0.0-20241129212102-9c50ad6b591e` to `v0.0.0-20260504013507-f4b012c11129`
- GitHub Actions workflow versions confirmed up to date (checkout@v6, setup-go@v6, cache@v5, golangci-lint-action@v9, codeql-action@v4)

## Test plan
- [ ] CI passes on push