### PR TITLE
mdbx: expose Refresh / Checkpoint / CommitEmbarkRead / Rollback / Amend / Clone txn APIs

### DIFF
--- a/mdbx/mdbxgo.c
+++ b/mdbx/mdbxgo.c
@@ -211,6 +211,18 @@ mdbxgo_commit_result mdbxgo_txn_commit_ex(MDBX_txn *txn) {
     return r;
 }
 
+mdbxgo_commit_result mdbxgo_txn_checkpoint(MDBX_txn *txn, MDBX_txn_flags_t weakening) {
+    mdbxgo_commit_result r = {0};
+    r.err = mdbx_txn_checkpoint(txn, weakening, &r.lat);
+    return r;
+}
+
+mdbxgo_commit_result mdbxgo_txn_commit_embark_read(MDBX_txn **ptxn) {
+    mdbxgo_commit_result r = {0};
+    r.err = mdbx_txn_commit_embark_read(ptxn, &r.lat);
+    return r;
+}
+
 mdbxgo_gc_info_result mdbxgo_gc_info(MDBX_txn *txn) {
     mdbxgo_gc_info_result r = {0};
     MDBX_gc_info_t info = {0};

--- a/mdbx/mdbxgo.h
+++ b/mdbx/mdbxgo.h
@@ -66,6 +66,8 @@ mdbxgo_uint_result       mdbxgo_dbi_open_ex(MDBX_txn *txn, const char *name, MDB
 
 typedef struct { int err; MDBX_commit_latency lat; } mdbxgo_commit_result;
 mdbxgo_commit_result     mdbxgo_txn_commit_ex(MDBX_txn *txn);
+mdbxgo_commit_result     mdbxgo_txn_checkpoint(MDBX_txn *txn, MDBX_txn_flags_t weakening);
+mdbxgo_commit_result     mdbxgo_txn_commit_embark_read(MDBX_txn **ptxn);
 
 typedef struct { int err; char *kbase; size_t klen; char *vbase; size_t vlen; } mdbxgo_val_result;
 mdbxgo_val_result        mdbxgo_cursor_get_empty(MDBX_cursor *cur, MDBX_cursor_op op);

--- a/mdbx/txn.go
+++ b/mdbx/txn.go
@@ -254,47 +254,45 @@ func (txn *Txn) commit() (CommitLatency, error) {
 	txn.strictThreadCheck()
 	r := C.mdbxgo_txn_commit_ex(txn._txn)
 	txn.clearTxn()
-	s := CommitLatency{
-		Preparation: toDuration(r.lat.preparation),
-		GCWallClock: toDuration(r.lat.gc_wallclock),
-		GCCpuTime:   toDuration(r.lat.gc_cputime),
-		Audit:       toDuration(r.lat.audit),
-		Write:       toDuration(r.lat.write),
-		Sync:        toDuration(r.lat.sync),
-		Ending:      toDuration(r.lat.ending),
-		Whole:       toDuration(r.lat.whole),
-		GCDetails: CommitLatencyGC{
-			WorkRtime:   toDuration(r.lat.gc_prof.work_rtime_monotonic),
-			WorkRsteps:  uint32(r.lat.gc_prof.work_rsteps),
-			WorkRxpages: uint32(r.lat.gc_prof.work_xpages),
-			WorkMajflt:  uint32(r.lat.gc_prof.work_majflt),
-			//WorkPnlMergeTime:   toDuration(r.lat.gc_prof.pnl_merge_work.time),
-			//WorkPnlMergeVolume: uint64(r.lat.gc_prof.pnl_merge_work.volume),
-			//WorkPnlMergeCalls:  uint32(r.lat.gc_prof.pnl_merge_work.calls),
-			//SelfPnlMergeTime:   toDuration(r.lat.gc_prof.pnl_merge_self.time),
-			//SelfPnlMergeVolume: uint64(r.lat.gc_prof.pnl_merge_self.volume),
-			//SelfPnlMergeCalls:  uint32(r.lat.gc_prof.pnl_merge_self.calls),
-			SelfRtime:        toDuration(r.lat.gc_prof.self_rtime_monotonic),
-			SelfXtime:        toDuration(r.lat.gc_prof.self_xtime_cpu),
-			WorkXtime:        toDuration(r.lat.gc_prof.work_xtime_cpu),
-			SelfRsteps:       uint32(r.lat.gc_prof.self_rsteps),
-			SelfXpages:       uint32(r.lat.gc_prof.self_xpages),
-			SelfMajflt:       uint32(r.lat.gc_prof.self_majflt),
-			Wloops:           uint32(r.lat.gc_prof.wloops),
-			Coalescences:     uint32(r.lat.gc_prof.coalescences),
-			Wipes:            uint32(r.lat.gc_prof.wipes),
-			Flushes:          uint32(r.lat.gc_prof.flushes),
-			Kicks:            uint32(r.lat.gc_prof.kicks),
-			MaxReaderLag:     uint32(r.lat.gc_prof.max_reader_lag),
-			MaxRetainedPages: uint32(r.lat.gc_prof.max_retained_pages),
-			SelfCounter:      uint32(r.lat.gc_prof.self_counter),
-			WorkCounter:      uint32(r.lat.gc_prof.work_counter),
-		},
-	}
+	s := buildCommitLatency(&r.lat)
 	if r.err != success {
 		return s, operrno("mdbx_txn_commit_ex", r.err)
 	}
 	return s, nil
+}
+
+func buildCommitLatency(lat *C.MDBX_commit_latency) CommitLatency {
+	return CommitLatency{
+		Preparation: toDuration(lat.preparation),
+		GCWallClock: toDuration(lat.gc_wallclock),
+		GCCpuTime:   toDuration(lat.gc_cputime),
+		Audit:       toDuration(lat.audit),
+		Write:       toDuration(lat.write),
+		Sync:        toDuration(lat.sync),
+		Ending:      toDuration(lat.ending),
+		Whole:       toDuration(lat.whole),
+		GCDetails: CommitLatencyGC{
+			WorkRtime:        toDuration(lat.gc_prof.work_rtime_monotonic),
+			WorkRsteps:       uint32(lat.gc_prof.work_rsteps),
+			WorkRxpages:      uint32(lat.gc_prof.work_xpages),
+			WorkMajflt:       uint32(lat.gc_prof.work_majflt),
+			SelfRtime:        toDuration(lat.gc_prof.self_rtime_monotonic),
+			SelfXtime:        toDuration(lat.gc_prof.self_xtime_cpu),
+			WorkXtime:        toDuration(lat.gc_prof.work_xtime_cpu),
+			SelfRsteps:       uint32(lat.gc_prof.self_rsteps),
+			SelfXpages:       uint32(lat.gc_prof.self_xpages),
+			SelfMajflt:       uint32(lat.gc_prof.self_majflt),
+			Wloops:           uint32(lat.gc_prof.wloops),
+			Coalescences:     uint32(lat.gc_prof.coalescences),
+			Wipes:            uint32(lat.gc_prof.wipes),
+			Flushes:          uint32(lat.gc_prof.flushes),
+			Kicks:            uint32(lat.gc_prof.kicks),
+			MaxReaderLag:     uint32(lat.gc_prof.max_reader_lag),
+			MaxRetainedPages: uint32(lat.gc_prof.max_retained_pages),
+			SelfCounter:      uint32(lat.gc_prof.self_counter),
+			WorkCounter:      uint32(lat.gc_prof.work_counter),
+		},
+	}
 }
 
 // Abort discards pending writes in the transaction and clears the finalizer on
@@ -431,6 +429,201 @@ func (txn *Txn) renew() error {
 	txn.resetID()
 
 	return operrno("mdbx_txn_renew", ret)
+}
+
+// Refresh advances a read-only transaction to the most recent MVCC-snapshot
+// without aborting and renewing the reader slot. It is cheaper than
+// Reset+Renew because it keeps the reader registration alive.
+//
+// The returned `atTip` bool is true when the transaction was already viewing
+// the latest snapshot and no work was performed.
+//
+// See mdbx_txn_refresh.
+func (txn *Txn) Refresh() (atTip bool, err error) {
+	if txn.managed {
+		panic("managed transaction cannot be refreshed directly")
+	}
+	ret := C.mdbx_txn_refresh(txn._txn)
+	txn.resetID()
+	if ret == C.MDBX_RESULT_TRUE {
+		return true, nil
+	}
+	return false, operrno("mdbx_txn_refresh", ret)
+}
+
+// Checkpoint commits the operations of the write transaction and immediately
+// starts a new write transaction reusing the same handle, without releasing
+// any locks. This is useful for breaking up long write pipelines into smaller
+// committed chunks while preventing other writers from interleaving.
+//
+// weakeningDurability may be used to relax sync/durability for the committed
+// changes (e.g. TxNoSync or TxNoMetaSync). Pass 0 for default durability.
+//
+// noChanges is true when the transaction contained no changes (MDBX_RESULT_TRUE).
+//
+// See mdbx_txn_checkpoint.
+func (txn *Txn) Checkpoint(weakeningDurability uint) (lat CommitLatency, noChanges bool, err error) {
+	if txn.managed {
+		panic("managed transaction cannot be checkpointed directly")
+	}
+	txn.strictThreadCheck()
+	r := C.mdbxgo_txn_checkpoint(txn._txn, C.MDBX_txn_flags_t(weakeningDurability))
+	lat = buildCommitLatency(&r.lat)
+	txn.resetID()
+	if r.err == C.MDBX_RESULT_TRUE {
+		return lat, true, nil
+	}
+	if r.err != success {
+		return lat, false, operrno("mdbx_txn_checkpoint", r.err)
+	}
+	return lat, false, nil
+}
+
+// CommitEmbarkRead commits the write transaction and atomically starts a new
+// read-only transaction observing the just-committed snapshot, all without
+// releasing the writer locks between the two operations. This guarantees that
+// no other writer can interleave a commit between the write commit and the
+// new reader.
+//
+// On success the same Txn handle is reused and transitions to read-only mode.
+// noChanges is true when the transaction had no changes to commit
+// (MDBX_RESULT_TRUE).
+//
+// See mdbx_txn_commit_embark_read.
+func (txn *Txn) CommitEmbarkRead() (lat CommitLatency, noChanges bool, err error) {
+	if txn.managed {
+		panic("managed transaction cannot be committed directly")
+	}
+	txn.strictThreadCheck()
+	r := C.mdbxgo_txn_commit_embark_read(&txn._txn)
+	lat = buildCommitLatency(&r.lat)
+	txn.resetID()
+	if r.err == C.MDBX_RESULT_TRUE {
+		// Reused as read txn even on no-op commit per docs.
+		txn.readonly = true
+		return lat, true, nil
+	}
+	if r.err != success {
+		// On error the transaction is terminated.
+		txn.clearTxn()
+		return lat, false, operrno("mdbx_txn_commit_embark_read", r.err)
+	}
+	txn.readonly = true
+	return lat, false, nil
+}
+
+// Rollback aborts all uncommitted changes in a write transaction and
+// immediately restarts it on a fresh snapshot, keeping the writer locks held.
+// Unlike Abort followed by BeginTxn, no other writer can grab the lock in
+// between.
+//
+// The Txn handle remains valid after a successful Rollback and may continue
+// to be used. On error, the transaction is terminated.
+//
+// See mdbx_txn_rollback.
+func (txn *Txn) Rollback() error {
+	if txn.managed {
+		panic("managed transaction cannot be rolled back directly")
+	}
+	txn.strictThreadCheck()
+	ret := C.mdbx_txn_rollback(txn._txn)
+	txn.resetID()
+	if ret == success {
+		return nil
+	}
+	// On failure libmdbx tears down the transaction.
+	txn.clearTxn()
+	return operrno("mdbx_txn_rollback", ret)
+}
+
+// Amend promotes a read-only transaction into a write transaction that
+// modifies data relative to the read transaction's MVCC-snapshot. This only
+// succeeds if no other write transaction has committed since the read
+// transaction started; otherwise snapshotTooOld is true and no actions have
+// been performed.
+//
+// If TxPrepareRO is included in flags, the original read transaction handle
+// is preserved (in reset state) and may be reused via Renew. Otherwise the
+// original read transaction handle is consumed and must not be used again.
+//
+// On success a new *Txn representing the write transaction is returned.
+//
+// See mdbx_txn_amend.
+func (txn *Txn) Amend(flags uint) (writeTxn *Txn, snapshotTooOld bool, err error) {
+	if txn.managed {
+		panic("managed transaction cannot be amended directly")
+	}
+	if !txn.readonly {
+		return nil, false, &OpError{Op: "mdbx_txn_amend", Errno: BadTxn}
+	}
+	txn.strictThreadCheck()
+
+	newTxn := &Txn{
+		env:      txn.env,
+		readonly: false,
+		tid:      txn.tid,
+	}
+	if txn.env.strictThreadCheck {
+		newTxn.tid = threads.CurrentThreadID()
+	}
+
+	ret := C.mdbx_txn_amend(txn._txn, &newTxn._txn, C.MDBX_txn_flags_t(flags), nil)
+	if ret == C.MDBX_RESULT_TRUE {
+		return nil, true, nil
+	}
+	if ret != success {
+		return nil, false, operrno("mdbx_txn_amend", ret)
+	}
+	// Original read txn is consumed unless TxPrepareRO was requested.
+	if flags&TxPrepareRO == 0 {
+		txn.clearTxn()
+	} else {
+		txn.resetID()
+	}
+	return newTxn, false, nil
+}
+
+// Clone creates a new read-only transaction that observes the same
+// MVCC-snapshot as the origin transaction. Cloning a write transaction is
+// also allowed and yields a read-only view of the pre-write snapshot (without
+// uncommitted changes).
+//
+// The origin transaction must not be used concurrently while Clone runs. It
+// is the caller's responsibility to keep the origin alive on its own thread
+// until this function returns.
+//
+// See mdbx_txn_clone.
+func (txn *Txn) Clone() (*Txn, error) {
+	cloned := &Txn{
+		env:      txn.env,
+		readonly: true,
+	}
+	if txn.env.strictThreadCheck {
+		cloned.tid = threads.CurrentThreadID()
+	}
+	ret := C.mdbx_txn_clone(txn._txn, &cloned._txn, nil)
+	if ret != success {
+		return nil, operrno("mdbx_txn_clone", ret)
+	}
+	return cloned, nil
+}
+
+// CloneInto re-uses an existing (reset) read-only transaction handle as the
+// destination for a clone of the origin transaction. The target *Txn must be
+// a reset read-only transaction obtained from the same Env. On success the
+// target is renewed against the origin's snapshot.
+//
+// See mdbx_txn_clone.
+func (txn *Txn) CloneInto(target *Txn) error {
+	if target == nil || target._txn == nil {
+		return &OpError{Op: "mdbx_txn_clone", Errno: BadTxn}
+	}
+	ret := C.mdbx_txn_clone(txn._txn, &target._txn, nil)
+	if ret != success {
+		return operrno("mdbx_txn_clone", ret)
+	}
+	target.resetID()
+	return nil
 }
 
 // OpenDBI opens a named database in the environment.  An error is returned if

--- a/mdbx/txn.go
+++ b/mdbx/txn.go
@@ -459,21 +459,42 @@ func (txn *Txn) Refresh() (atTip bool, err error) {
 // weakeningDurability may be used to relax sync/durability for the committed
 // changes (e.g. TxNoSync or TxNoMetaSync). Pass 0 for default durability.
 //
-// noChanges is true when the transaction contained no changes (MDBX_RESULT_TRUE).
+// noChanges is true when the transaction contained no changes
+// (MDBX_RESULT_TRUE); in that case the txn handle is left untouched and
+// remains usable.
+//
+// WARNING: A successful Checkpoint internally tears down and restarts the
+// underlying libmdbx transaction. All cursors opened against this Txn become
+// invalid C handles after Checkpoint returns. Close all cursors (or stop
+// using them) before calling Checkpoint — libmdbx does not currently support
+// cursor transfer across the restart.
+//
+// On a non-RESULT_TRUE error the libmdbx commit path terminates the handle
+// internally; the wrapper clears it so a deferred Abort/Commit is a no-op.
 //
 // See mdbx_txn_checkpoint.
 func (txn *Txn) Checkpoint(weakeningDurability uint) (lat CommitLatency, noChanges bool, err error) {
 	if txn.managed {
 		panic("managed transaction cannot be checkpointed directly")
 	}
+	if txn.readonly {
+		return CommitLatency{}, false, &OpError{Op: "mdbx_txn_checkpoint", Errno: BadTxn}
+	}
 	txn.strictThreadCheck()
 	r := C.mdbxgo_txn_checkpoint(txn._txn, C.MDBX_txn_flags_t(weakeningDurability))
 	lat = buildCommitLatency(&r.lat)
 	txn.resetID()
 	if r.err == C.MDBX_RESULT_TRUE {
+		// No dirty pages; handle is still live and reusable.
 		return lat, true, nil
 	}
 	if r.err != success {
+		// Commit-path failures inside txn_basal_checkpoint terminate the C
+		// handle via txn_basal_end(true). Pre-validation errors (BAD_TXN,
+		// EINVAL, THREAD_MISMATCH) leave the handle alive, but they also
+		// poison the wrapper's bookkeeping; we drop the reference to keep the
+		// post-error invariant of "handle is gone" symmetric with commit().
+		txn.clearTxn()
 		return lat, false, operrno("mdbx_txn_checkpoint", r.err)
 	}
 	return lat, false, nil
@@ -481,13 +502,22 @@ func (txn *Txn) Checkpoint(weakeningDurability uint) (lat CommitLatency, noChang
 
 // CommitEmbarkRead commits the write transaction and atomically starts a new
 // read-only transaction observing the just-committed snapshot, all without
-// releasing the writer locks between the two operations. This guarantees that
-// no other writer can interleave a commit between the write commit and the
-// new reader.
+// releasing the writer locks between the two operations. This guarantees
+// that no other writer can interleave a commit between the write commit and
+// the new reader.
 //
-// On success the same Txn handle is reused and transitions to read-only mode.
-// noChanges is true when the transaction had no changes to commit
-// (MDBX_RESULT_TRUE).
+// On success the same Txn handle is reused and transitions to read-only
+// mode.
+//
+// noChanges is true when libmdbx returned MDBX_RESULT_TRUE (no dirty pages
+// to commit). On that path libmdbx terminates the write handle without
+// allocating a read replacement, so the Txn is no longer usable; the wrapper
+// clears it. The noChanges path is only reachable in builds with
+// MDBX_NOSUCCESS_PURE_COMMIT enabled — under the default build a no-op
+// commit succeeds normally.
+//
+// WARNING: All cursors opened against this Txn become invalid C handles
+// after CommitEmbarkRead returns. Close them before calling.
 //
 // See mdbx_txn_commit_embark_read.
 //
@@ -496,45 +526,74 @@ func (txn *Txn) CommitEmbarkRead() (lat CommitLatency, noChanges bool, err error
 	if txn.managed {
 		panic("managed transaction cannot be committed directly")
 	}
+	if txn.readonly {
+		return CommitLatency{}, false, &OpError{Op: "mdbx_txn_commit_embark_read", Errno: BadTxn}
+	}
 	txn.strictThreadCheck()
 	r := C.mdbxgo_txn_commit_embark_read(&txn._txn)
 	lat = buildCommitLatency(&r.lat)
 	txn.resetID()
 	if r.err == C.MDBX_RESULT_TRUE {
-		// Reused as read txn even on no-op commit per docs.
-		txn.readonly = true
+		// libmdbx wrote nullptr into *ptxn on this path (no read txn was
+		// allocated) and terminated the original write handle. The Txn is
+		// dead — clear it explicitly and surface noChanges=true.
+		txn.clearTxn()
 		return lat, true, nil
 	}
 	if r.err != success {
-		// On error the transaction is terminated.
-		txn.clearTxn()
+		// On commit-path failures libmdbx writes nullptr into *ptxn after
+		// terminating the original handle. On pre-validation errors
+		// (BAD_TXN, EINVAL, THREAD_MISMATCH) libmdbx leaves *ptxn untouched
+		// and the original write handle is still alive — let the caller
+		// Abort() it themselves rather than silently dropping it.
+		if txn._txn == nil {
+			txn.clearTxn()
+		}
 		return lat, false, operrno("mdbx_txn_commit_embark_read", r.err)
 	}
+	// Success: txn._txn now points to a freshly-started read-only txn.
 	txn.readonly = true
 	return lat, false, nil
 }
 
 // Rollback aborts all uncommitted changes in a write transaction and
-// immediately restarts it on a fresh snapshot, keeping the writer locks held.
-// Unlike Abort followed by BeginTxn, no other writer can grab the lock in
-// between.
+// immediately restarts it on a fresh snapshot, keeping the writer locks
+// held. Unlike Abort followed by BeginTxn, no other writer can grab the lock
+// in between.
 //
 // The Txn handle remains valid after a successful Rollback and may continue
-// to be used. On error, the transaction is terminated.
+// to be used. On error the wrapper does NOT clear the handle — libmdbx's
+// pre-validation errors (BAD_TXN, EINVAL, THREAD_MISMATCH) leave the
+// transaction intact, and the caller is expected to call Abort() to release
+// it. Treating MDBX_RESULT_TRUE as a silent success is defensive: the
+// current libmdbx code does not return it for rollback, but the public docs
+// list it as a possible return.
+//
+// WARNING: All cursors opened against this Txn become invalid C handles
+// after a successful Rollback. libmdbx tears them down via
+// txn_done_cursors() before the restart. Close cursors before calling.
 //
 // See mdbx_txn_rollback.
 func (txn *Txn) Rollback() error {
 	if txn.managed {
 		panic("managed transaction cannot be rolled back directly")
 	}
+	if txn.readonly {
+		return &OpError{Op: "mdbx_txn_rollback", Errno: BadTxn}
+	}
 	txn.strictThreadCheck()
 	ret := C.mdbx_txn_rollback(txn._txn)
 	txn.resetID()
-	if ret == success {
+	if ret == success || ret == C.MDBX_RESULT_TRUE {
+		// RESULT_TRUE: per docs "no actions have been performed"; handle is
+		// still alive. Treat exactly like success.
 		return nil
 	}
-	// On failure libmdbx tears down the transaction.
-	txn.clearTxn()
+	// Pre-validation errors leave the handle alive. Mid-rollback failures
+	// (txn_basal_end / txn_basal_start) may leave it half-terminated, but we
+	// preserve the pointer so the caller can Abort() — calling Abort on an
+	// already-finished handle is recoverable (BAD_TXN), calling it on a nil
+	// handle is silent and leaks the slot.
 	return operrno("mdbx_txn_rollback", ret)
 }
 
@@ -549,6 +608,10 @@ func (txn *Txn) Rollback() error {
 // original read transaction handle is consumed and must not be used again.
 //
 // On success a new *Txn representing the write transaction is returned.
+//
+// WARNING: Cursors opened against the original read transaction are not
+// transferred to the new write transaction. Close them before calling Amend
+// (or, with TxPrepareRO, after the call but before Renew).
 //
 // See mdbx_txn_amend.
 //
@@ -619,11 +682,16 @@ func (txn *Txn) Clone() (*Txn, error) {
 // a reset read-only transaction obtained from the same Env. On success the
 // target is renewed against the origin's snapshot.
 //
+// Passing a write (non-readonly) target is rejected here rather than at the
+// libmdbx layer: the C bailout for a write target would invoke
+// txn_ro_reset() on the write handle, corrupting its state. See
+// mdbx_txn_clone in mdbx.c.
+//
 // See mdbx_txn_clone.
 //
 //nolint:gocritic // false positive on dupSubExpr
 func (txn *Txn) CloneInto(target *Txn) error {
-	if target == nil || target._txn == nil {
+	if target == nil || target._txn == nil || !target.readonly {
 		return &OpError{Op: "mdbx_txn_clone", Errno: BadTxn}
 	}
 	ret := C.mdbx_txn_clone(txn._txn, &target._txn, nil)

--- a/mdbx/txn.go
+++ b/mdbx/txn.go
@@ -490,6 +490,8 @@ func (txn *Txn) Checkpoint(weakeningDurability uint) (lat CommitLatency, noChang
 // (MDBX_RESULT_TRUE).
 //
 // See mdbx_txn_commit_embark_read.
+//
+//nolint:gocritic // false positive on dupSubExpr
 func (txn *Txn) CommitEmbarkRead() (lat CommitLatency, noChanges bool, err error) {
 	if txn.managed {
 		panic("managed transaction cannot be committed directly")
@@ -549,6 +551,8 @@ func (txn *Txn) Rollback() error {
 // On success a new *Txn representing the write transaction is returned.
 //
 // See mdbx_txn_amend.
+//
+//nolint:gocritic // false positive on dupSubExpr
 func (txn *Txn) Amend(flags uint) (writeTxn *Txn, snapshotTooOld bool, err error) {
 	if txn.managed {
 		panic("managed transaction cannot be amended directly")
@@ -593,6 +597,8 @@ func (txn *Txn) Amend(flags uint) (writeTxn *Txn, snapshotTooOld bool, err error
 // until this function returns.
 //
 // See mdbx_txn_clone.
+//
+//nolint:gocritic // false positive on dupSubExpr
 func (txn *Txn) Clone() (*Txn, error) {
 	cloned := &Txn{
 		env:      txn.env,
@@ -614,6 +620,8 @@ func (txn *Txn) Clone() (*Txn, error) {
 // target is renewed against the origin's snapshot.
 //
 // See mdbx_txn_clone.
+//
+//nolint:gocritic // false positive on dupSubExpr
 func (txn *Txn) CloneInto(target *Txn) error {
 	if target == nil || target._txn == nil {
 		return &OpError{Op: "mdbx_txn_clone", Errno: BadTxn}

--- a/mdbx/txn_test.go
+++ b/mdbx/txn_test.go
@@ -1420,3 +1420,445 @@ func TestTxnEnvWarmup(t *testing.T) {
 	}
 	defer txn.Abort()
 }
+
+// TestTxn_Refresh exercises mdbx_txn_refresh against a read-only transaction.
+// After a write has occurred, refreshing the older reader must expose the
+// new value without going through Reset/Renew.
+func TestTxn_Refresh(t *testing.T) {
+	env, _ := setup(t)
+
+	var dbi DBI
+	if err := env.Update(func(txn *Txn) (err error) {
+		dbi, err = txn.OpenDBISimple("refresh", Create)
+		return err
+	}); err != nil {
+		t.Fatalf("create dbi: %v", err)
+	}
+
+	roTxn, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin ro: %v", err)
+	}
+	defer roTxn.Abort()
+
+	// Already at tip — nothing committed since this snapshot started.
+	atTip, err := roTxn.Refresh()
+	if err != nil {
+		t.Fatalf("refresh (tip): %v", err)
+	}
+	if !atTip {
+		t.Errorf("expected atTip=true on freshly-started reader")
+	}
+
+	if _, err := roTxn.Get(dbi, []byte("k")); !IsNotFound(err) {
+		t.Errorf("expected NotFound before write, got %v", err)
+	}
+
+	if err := env.Update(func(txn *Txn) error {
+		return txn.Put(dbi, []byte("k"), []byte("v"), 0)
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Reader still sees the old snapshot before refresh.
+	if _, err := roTxn.Get(dbi, []byte("k")); !IsNotFound(err) {
+		t.Errorf("expected NotFound on stale snapshot, got %v", err)
+	}
+
+	atTip, err = roTxn.Refresh()
+	if err != nil {
+		t.Fatalf("refresh (advance): %v", err)
+	}
+	if atTip {
+		t.Errorf("expected atTip=false after a fresh commit landed")
+	}
+
+	v, err := roTxn.Get(dbi, []byte("k"))
+	if err != nil {
+		t.Fatalf("get after refresh: %v", err)
+	}
+	if string(v) != "v" {
+		t.Errorf("unexpected value after refresh: %q", v)
+	}
+}
+
+// TestTxn_Checkpoint commits a chunk of work in the middle of a longer write
+// pipeline and verifies the data is visible to a new reader without
+// releasing the write lock.
+func TestTxn_Checkpoint(t *testing.T) {
+	env, _ := setup(t)
+
+	var dbi DBI
+	if err := env.Update(func(txn *Txn) (err error) {
+		dbi, err = txn.OpenDBISimple("ckpt", Create)
+		return err
+	}); err != nil {
+		t.Fatalf("create dbi: %v", err)
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	txn, err := env.BeginTxn(nil, 0)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() {
+		if txn._txn != nil {
+			txn.Abort()
+		}
+	}()
+
+	if err := txn.Put(dbi, []byte("a"), []byte("1"), 0); err != nil {
+		t.Fatalf("put a: %v", err)
+	}
+
+	lat, noChanges, err := txn.Checkpoint(0)
+	if err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if noChanges {
+		t.Errorf("expected noChanges=false after a put")
+	}
+	_ = lat // latency is informational
+
+	// Pipeline continues in the same write txn.
+	if err := txn.Put(dbi, []byte("b"), []byte("2"), 0); err != nil {
+		t.Fatalf("put b: %v", err)
+	}
+
+	// First key must be visible to a fresh reader (mid-pipeline).
+	if err := env.View(func(view *Txn) error {
+		got, gerr := view.Get(dbi, []byte("a"))
+		if gerr != nil {
+			return fmt.Errorf("get a: %w", gerr)
+		}
+		if string(got) != "1" {
+			return fmt.Errorf("a=%q, want %q", got, "1")
+		}
+		// b not yet committed
+		if _, gerr := view.Get(dbi, []byte("b")); !IsNotFound(gerr) {
+			return fmt.Errorf("b visible before second commit: %v", gerr)
+		}
+		return nil
+	}); err != nil {
+		t.Errorf("mid-pipeline view: %v", err)
+	}
+
+	if _, err := txn.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	if err := env.View(func(view *Txn) error {
+		got, gerr := view.Get(dbi, []byte("b"))
+		if gerr != nil {
+			return fmt.Errorf("get b: %w", gerr)
+		}
+		if string(got) != "2" {
+			return fmt.Errorf("b=%q, want %q", got, "2")
+		}
+		return nil
+	}); err != nil {
+		t.Errorf("final view: %v", err)
+	}
+}
+
+// TestTxn_Checkpoint_NoChanges asserts the noChanges flag is returned when a
+// write transaction is checkpointed without any modifications.
+func TestTxn_Checkpoint_NoChanges(t *testing.T) {
+	env, _ := setup(t)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	txn, err := env.BeginTxn(nil, 0)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() {
+		if txn._txn != nil {
+			txn.Abort()
+		}
+	}()
+
+	_, noChanges, err := txn.Checkpoint(0)
+	if err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if !noChanges {
+		t.Errorf("expected noChanges=true for an empty write txn")
+	}
+}
+
+// TestTxn_CommitEmbarkRead commits a write txn and immediately observes the
+// resulting snapshot through the same handle (now in read-only mode).
+func TestTxn_CommitEmbarkRead(t *testing.T) {
+	env, _ := setup(t)
+
+	var dbi DBI
+	if err := env.Update(func(txn *Txn) (err error) {
+		dbi, err = txn.OpenDBISimple("embark", Create)
+		return err
+	}); err != nil {
+		t.Fatalf("create dbi: %v", err)
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	txn, err := env.BeginTxn(nil, 0)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() {
+		if txn._txn != nil {
+			txn.Abort()
+		}
+	}()
+
+	if err := txn.Put(dbi, []byte("k"), []byte("v"), 0); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	_, noChanges, err := txn.CommitEmbarkRead()
+	if err != nil {
+		t.Fatalf("commit embark read: %v", err)
+	}
+	if noChanges {
+		t.Errorf("expected noChanges=false after a put")
+	}
+	if !txn.readonly {
+		t.Errorf("expected txn to be read-only after CommitEmbarkRead")
+	}
+
+	got, err := txn.Get(dbi, []byte("k"))
+	if err != nil {
+		t.Fatalf("get on embarked read: %v", err)
+	}
+	if string(got) != "v" {
+		t.Errorf("unexpected value on embarked read: %q", got)
+	}
+}
+
+// TestTxn_Rollback verifies that writes performed before Rollback are
+// discarded but the same Txn handle can continue to be used.
+func TestTxn_Rollback(t *testing.T) {
+	env, _ := setup(t)
+
+	var dbi DBI
+	if err := env.Update(func(txn *Txn) (err error) {
+		dbi, err = txn.OpenDBISimple("rollback", Create)
+		return err
+	}); err != nil {
+		t.Fatalf("create dbi: %v", err)
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	txn, err := env.BeginTxn(nil, 0)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() {
+		if txn._txn != nil {
+			txn.Abort()
+		}
+	}()
+
+	if err := txn.Put(dbi, []byte("dropped"), []byte("x"), 0); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	if err := txn.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if txn._txn == nil {
+		t.Fatal("Rollback unexpectedly tore down the txn handle")
+	}
+
+	// The handle must still be usable for further writes.
+	if _, err := txn.Get(dbi, []byte("dropped")); !IsNotFound(err) {
+		t.Errorf("expected NotFound after Rollback, got %v", err)
+	}
+	if err := txn.Put(dbi, []byte("kept"), []byte("y"), 0); err != nil {
+		t.Fatalf("put after rollback: %v", err)
+	}
+	if _, err := txn.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	if err := env.View(func(view *Txn) error {
+		if _, gerr := view.Get(dbi, []byte("dropped")); !IsNotFound(gerr) {
+			return fmt.Errorf("rolled-back key visible: %v", gerr)
+		}
+		got, gerr := view.Get(dbi, []byte("kept"))
+		if gerr != nil {
+			return fmt.Errorf("get kept: %w", gerr)
+		}
+		if string(got) != "y" {
+			return fmt.Errorf("kept=%q, want %q", got, "y")
+		}
+		return nil
+	}); err != nil {
+		t.Errorf("post-rollback view: %v", err)
+	}
+}
+
+// TestTxn_Amend converts a fresh read snapshot into a write transaction and
+// commits a modification to that snapshot.
+func TestTxn_Amend(t *testing.T) {
+	env, _ := setup(t)
+
+	var dbi DBI
+	if err := env.Update(func(txn *Txn) (err error) {
+		dbi, err = txn.OpenDBISimple("amend", Create)
+		return err
+	}); err != nil {
+		t.Fatalf("create dbi: %v", err)
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	ro, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin ro: %v", err)
+	}
+	defer func() {
+		if ro._txn != nil {
+			ro.Abort()
+		}
+	}()
+
+	writeTxn, snapshotTooOld, err := ro.Amend(0)
+	if err != nil {
+		t.Fatalf("amend: %v", err)
+	}
+	if snapshotTooOld {
+		t.Fatal("unexpected snapshotTooOld for an untouched snapshot")
+	}
+	if writeTxn == nil {
+		t.Fatal("expected non-nil write txn")
+	}
+	if ro._txn != nil {
+		t.Errorf("expected original read txn handle to be consumed without TxPrepareRO")
+	}
+
+	if err := writeTxn.Put(dbi, []byte("amended"), []byte("ok"), 0); err != nil {
+		writeTxn.Abort()
+		t.Fatalf("put: %v", err)
+	}
+	if _, err := writeTxn.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	if err := env.View(func(view *Txn) error {
+		got, gerr := view.Get(dbi, []byte("amended"))
+		if gerr != nil {
+			return fmt.Errorf("get amended: %w", gerr)
+		}
+		if string(got) != "ok" {
+			return fmt.Errorf("amended=%q, want %q", got, "ok")
+		}
+		return nil
+	}); err != nil {
+		t.Errorf("post-amend view: %v", err)
+	}
+}
+
+// TestTxn_Amend_SnapshotTooOld asserts the snapshotTooOld signal is set when
+// the read transaction's snapshot has been superseded by a committed write.
+func TestTxn_Amend_SnapshotTooOld(t *testing.T) {
+	env, _ := setup(t)
+
+	var dbi DBI
+	if err := env.Update(func(txn *Txn) (err error) {
+		dbi, err = txn.OpenDBISimple("amend_stale", Create)
+		return err
+	}); err != nil {
+		t.Fatalf("create dbi: %v", err)
+	}
+
+	ro, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin ro: %v", err)
+	}
+	defer ro.Abort()
+
+	// Race a write past the read snapshot.
+	if err := env.Update(func(txn *Txn) error {
+		return txn.Put(dbi, []byte("racer"), []byte("1"), 0)
+	}); err != nil {
+		t.Fatalf("race write: %v", err)
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	writeTxn, snapshotTooOld, err := ro.Amend(0)
+	if err != nil {
+		t.Fatalf("amend: %v", err)
+	}
+	if !snapshotTooOld {
+		if writeTxn != nil {
+			writeTxn.Abort()
+		}
+		t.Fatalf("expected snapshotTooOld=true after concurrent commit")
+	}
+	if writeTxn != nil {
+		t.Errorf("expected nil writeTxn on snapshotTooOld")
+	}
+}
+
+// TestTxn_Clone creates a clone of a read transaction and verifies it sees
+// the same MVCC snapshot independently of the origin.
+func TestTxn_Clone(t *testing.T) {
+	env, _ := setup(t)
+
+	var dbi DBI
+	if err := env.Update(func(txn *Txn) (err error) {
+		dbi, err = txn.OpenDBISimple("clone", Create)
+		if err != nil {
+			return err
+		}
+		return txn.Put(dbi, []byte("k"), []byte("v0"), 0)
+	}); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	origin, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer origin.Abort()
+
+	clone, err := origin.Clone()
+	if err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	defer clone.Abort()
+
+	if clone.ID() != origin.ID() {
+		t.Errorf("clone id %d != origin id %d", clone.ID(), origin.ID())
+	}
+
+	// A subsequent commit must not be visible to either the origin or the
+	// clone — they both share the same pre-commit MVCC snapshot.
+	if err := env.Update(func(txn *Txn) error {
+		return txn.Put(dbi, []byte("k"), []byte("v1"), 0)
+	}); err != nil {
+		t.Fatalf("post-clone write: %v", err)
+	}
+
+	for name, view := range map[string]*Txn{"origin": origin, "clone": clone} {
+		got, gerr := view.Get(dbi, []byte("k"))
+		if gerr != nil {
+			t.Errorf("%s get: %v", name, gerr)
+			continue
+		}
+		if string(got) != "v0" {
+			t.Errorf("%s saw %q, want %q", name, got, "v0")
+		}
+	}
+}

--- a/mdbx/txn_test.go
+++ b/mdbx/txn_test.go
@@ -1538,7 +1538,7 @@ func TestTxn_Checkpoint(t *testing.T) {
 		}
 		// b not yet committed
 		if _, gerr := view.Get(dbi, []byte("b")); !IsNotFound(gerr) {
-			return fmt.Errorf("b visible before second commit: %v", gerr)
+			return fmt.Errorf("b visible before second commit: %w", gerr)
 		}
 		return nil
 	}); err != nil {
@@ -1690,7 +1690,7 @@ func TestTxn_Rollback(t *testing.T) {
 
 	if err := env.View(func(view *Txn) error {
 		if _, gerr := view.Get(dbi, []byte("dropped")); !IsNotFound(gerr) {
-			return fmt.Errorf("rolled-back key visible: %v", gerr)
+			return fmt.Errorf("rolled-back key visible: %w", gerr)
 		}
 		got, gerr := view.Get(dbi, []byte("kept"))
 		if gerr != nil {

--- a/mdbx/txn_test.go
+++ b/mdbx/txn_test.go
@@ -1862,3 +1862,152 @@ func TestTxn_Clone(t *testing.T) {
 		}
 	}
 }
+
+// TestTxn_Checkpoint_OnReadOnly verifies the !readonly guard on Checkpoint:
+// calling it on a read txn must return BadTxn without destroying the handle.
+func TestTxn_Checkpoint_OnReadOnly(t *testing.T) {
+	env, _ := setup(t)
+
+	ro, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin ro: %v", err)
+	}
+	defer ro.Abort()
+
+	_, _, err = ro.Checkpoint(0)
+	if !IsErrno(err, BadTxn) {
+		t.Fatalf("expected BadTxn from Checkpoint on read txn, got %v", err)
+	}
+	if ro._txn == nil {
+		t.Fatal("read txn handle was destroyed by failed Checkpoint guard")
+	}
+	// Reader must still be usable after the failed guard.
+	if _, gerr := ro.OpenRoot(0); gerr != nil {
+		t.Fatalf("read txn unusable after guard: %v", gerr)
+	}
+}
+
+// TestTxn_Rollback_OnReadOnly verifies the !readonly guard on Rollback.
+func TestTxn_Rollback_OnReadOnly(t *testing.T) {
+	env, _ := setup(t)
+
+	ro, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin ro: %v", err)
+	}
+	defer ro.Abort()
+
+	if err := ro.Rollback(); !IsErrno(err, BadTxn) {
+		t.Fatalf("expected BadTxn from Rollback on read txn, got %v", err)
+	}
+	if ro._txn == nil {
+		t.Fatal("read txn handle was destroyed by failed Rollback guard")
+	}
+	if _, gerr := ro.OpenRoot(0); gerr != nil {
+		t.Fatalf("read txn unusable after guard: %v", gerr)
+	}
+}
+
+// TestTxn_CommitEmbarkRead_OnReadOnly verifies the !readonly guard.
+func TestTxn_CommitEmbarkRead_OnReadOnly(t *testing.T) {
+	env, _ := setup(t)
+
+	ro, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin ro: %v", err)
+	}
+	defer ro.Abort()
+
+	_, _, err = ro.CommitEmbarkRead()
+	if !IsErrno(err, BadTxn) {
+		t.Fatalf("expected BadTxn from CommitEmbarkRead on read txn, got %v", err)
+	}
+	if ro._txn == nil {
+		t.Fatal("read txn handle was destroyed by failed CommitEmbarkRead guard")
+	}
+}
+
+// TestTxn_CloneInto_RejectsWriteTarget verifies that CloneInto refuses a
+// write-txn target before invoking libmdbx (which would otherwise reset the
+// write handle via its read-only bailout, corrupting state).
+func TestTxn_CloneInto_RejectsWriteTarget(t *testing.T) {
+	env, _ := setup(t)
+
+	// A live read source.
+	src, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin src: %v", err)
+	}
+	defer src.Abort()
+
+	// A live write target — must be rejected at the wrapper boundary.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	writeTarget, err := env.BeginTxn(nil, 0)
+	if err != nil {
+		t.Fatalf("begin write target: %v", err)
+	}
+	defer func() {
+		if writeTarget._txn != nil {
+			writeTarget.Abort()
+		}
+	}()
+
+	if err := src.CloneInto(writeTarget); !IsErrno(err, BadTxn) {
+		t.Fatalf("expected BadTxn from CloneInto with write target, got %v", err)
+	}
+	if writeTarget._txn == nil {
+		t.Fatal("write target handle was corrupted by CloneInto")
+	}
+	// Sanity: the write target is still usable as a write txn.
+	root, gerr := writeTarget.OpenRoot(0)
+	if gerr != nil {
+		t.Fatalf("write target unusable after rejected CloneInto: %v", gerr)
+	}
+	if perr := writeTarget.Put(root, []byte("k"), []byte("v"), 0); perr != nil {
+		t.Fatalf("put on write target failed: %v", perr)
+	}
+}
+
+// TestTxn_CloneInto_Reuse exercises the happy path of reusing an existing
+// (reset) read-only handle as the clone destination.
+func TestTxn_CloneInto_Reuse(t *testing.T) {
+	env, _ := setup(t)
+
+	var dbi DBI
+	if err := env.Update(func(txn *Txn) (err error) {
+		dbi, err = txn.OpenDBISimple("clone_into", Create)
+		if err != nil {
+			return err
+		}
+		return txn.Put(dbi, []byte("k"), []byte("v"), 0)
+	}); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	src, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin src: %v", err)
+	}
+	defer src.Abort()
+
+	target, err := env.BeginTxn(nil, Readonly)
+	if err != nil {
+		t.Fatalf("begin target: %v", err)
+	}
+	defer target.Abort()
+
+	if err := src.CloneInto(target); err != nil {
+		t.Fatalf("clone into: %v", err)
+	}
+	if target.ID() != src.ID() {
+		t.Errorf("target id %d != src id %d after CloneInto", target.ID(), src.ID())
+	}
+	got, gerr := target.Get(dbi, []byte("k"))
+	if gerr != nil {
+		t.Fatalf("get on cloned target: %v", gerr)
+	}
+	if string(got) != "v" {
+		t.Errorf("target saw %q, want %q", got, "v")
+	}
+}


### PR DESCRIPTION
## Summary

Wrap the libmdbx transaction-lifecycle primitives that were not yet surfaced by mdbx-go:

| New method | C call | What it gives you |
|---|---|---|
| `Txn.Refresh()` | `mdbx_txn_refresh` | Advance a read-only txn to the latest MVCC snapshot without `Reset`+`Renew` (keeps the reader slot live). |
| `Txn.Checkpoint(weakening)` | `mdbx_txn_checkpoint` | Commit a write txn and restart it on the same handle while **keeping the writer lock**. Splits long pipelines (e.g. Erigon staged sync) into committed chunks without losing exclusivity. |
| `Txn.CommitEmbarkRead()` | `mdbx_txn_commit_embark_read` | Atomically commit a write txn and start a read-only txn on the just-committed snapshot — no other writer can interleave. |
| `Txn.Rollback()` | `mdbx_txn_rollback` | Drop uncommitted changes of a write txn and restart it on a fresh snapshot while retaining the writer lock. |
| `Txn.Amend(flags)` | `mdbx_txn_amend` | Promote a read txn into a write txn that amends its MVCC snapshot. Honors `TxPrepareRO` (preserves original handle) and reports `snapshotTooOld` when the snapshot is bygone. |
| `Txn.Clone()` / `Txn.CloneInto(target)` | `mdbx_txn_clone` | Create (or refresh into) a read-only txn that shares the origin's MVCC snapshot — works from both read and write origins. |

`MDBX_RESULT_TRUE` outcomes are surfaced as explicit booleans (`atTip`, `noChanges`, `snapshotTooOld`) rather than swallowed by `operrno`, matching libmdbx's documented semantics.

## Implementation notes

- Added two cgo helpers in `mdbx/mdbxgo.{h,c}` (`mdbxgo_txn_checkpoint`, `mdbxgo_txn_commit_embark_read`) so the latency struct doesn't escape to the Go heap.
- Factored the commit-latency conversion in `Txn.commit()` into a shared `buildCommitLatency()` helper used by Commit / Checkpoint / CommitEmbarkRead.
- All wrappers perform `strictThreadCheck()` where the underlying call mandates the txn's owning thread.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./mdbx/` (full suite passes)
- [x] New tests added in `mdbx/txn_test.go`:
  - `TestTxn_Refresh` — covers both the at-tip path and the snapshot-advance path
  - `TestTxn_Checkpoint` — verifies mid-pipeline visibility to a new reader
  - `TestTxn_Checkpoint_NoChanges` — exercises the `MDBX_RESULT_TRUE` branch
  - `TestTxn_CommitEmbarkRead` — verifies the same handle is reusable as a reader
  - `TestTxn_Rollback` — discarded vs retained writes after rollback
  - `TestTxn_Amend` — happy path commit through an amended snapshot
  - `TestTxn_Amend_SnapshotTooOld` — concurrent commit produces `snapshotTooOld=true`
  - `TestTxn_Clone` — origin and clone share the pre-commit snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)