### PR TITLE
mdbx: expose OptPrefaultWriteEnable

### DIFF
--- a/mdbx/env.go
+++ b/mdbx/env.go
@@ -109,6 +109,11 @@ const (
 	OptMergeThreshold16dot16Percent = C.MDBX_opt_merge_threshold
 	OptPreferWafInsteadofBalance    = C.MDBX_opt_prefer_waf_insteadof_balance
 	OptGCTimeLimit                  = C.MDBX_opt_gc_time_limit
+	// OptPrefaultWriteEnable controls the prefault-write optimization (mincore() + pwrite()
+	// of each not-in-core page before it is touched via the writemap). It only pays off when
+	// the database is much larger than RAM; when the working set fits in RAM it is pure
+	// overhead. Set to 0 to disable, 1 to force-enable, or use the env default when unset.
+	OptPrefaultWriteEnable = C.MDBX_opt_prefault_write_enable
 )
 
 var (


### PR DESCRIPTION
## What

Exposes `MDBX_opt_prefault_write_enable` in the Go binding as `OptPrefaultWriteEnable`, so callers can control the prefault-write optimization:

```go
env.SetOption(mdbx.OptPrefaultWriteEnable, 0) // disable
```

## Why

In a 30s erigon commitment profile on a ~10GB DB with 4KB pages (working set fits in RAM), `page_alloc_finalize` was ~6.7% of CPU. Most of its self-time is intrinsic first-touch minor page-faults under `MDBX_WRITEMAP`, but on top of that the prefault-write path spends an avoidable **`mincore()` (0.37s) + `pwrite()` (0.32s)** per not-in-core page.

Prefault-write only earns its keep when the DB is much larger than RAM (it converts a major fault / disk read into a `pwrite`). When the working set fits in RAM there are no major faults to prevent, so it is pure overhead. This option lets such deployments turn it off.

## Notes

- Binding-only change (no `libmdbx/mdbx.c` edits), so nothing to upstream and no amalgamation-sync friction.
- An earlier revision of this PR also tried a C-side heuristic to skip prefault for "fresh" file-extending pages. Dropped it: it changed a vendored upstream function signature, and "file-extending" is only a *proxy* for "no on-disk content" (a shrink-without-truncate then re-grow could leave real evicted content above the allocation pointer, turning the skip into a missed prefault). The explicit option delivers the same win for the fits-in-RAM case with zero risk.
- `go test ./mdbx/` passes.