### PR TITLE
mdbx: expose range estimation + cursor distribution/deletion APIs

### DIFF
--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -404,9 +404,11 @@ func (c *Cursor) DeleteRange(end *Cursor, endIncluding bool) (numberAffected uin
 }
 
 // EstimateDistance estimates the number of elements between the position of the
-// receiver cursor and the position of last. Both cursors must be positioned and
-// initialized for the same table and transaction. The result is a rough estimate
-// suitable for building/optimizing query plans, not an exact count.
+// receiver cursor and the position of last. Both cursors must be non-nil,
+// positioned, and initialized for the same table and transaction. Unlike
+// Distance, this estimate has no end-of-table sentinel: a nil last is not a
+// valid argument. The result is a rough estimate suitable for building/optimizing
+// query plans, not an exact count.
 //
 // See mdbx_estimate_distance.
 func (c *Cursor) EstimateDistance(last *Cursor) (int, error) {
@@ -491,9 +493,9 @@ func (c *Cursor) Scroll(amount int, deepness uint) error {
 // (e.g. concurrent range deletion or warm-up).
 //
 // A nil first means the beginning of the table and a nil last means the end;
-// at least one of them must be non-nil and positioned. All cursors must be bound
-// to the same table and transaction. cursors must contain at least one cursor
-// that is neither first nor last.
+// at least one of them must be non-nil and positioned. Every entry in cursors
+// must be a non-nil open cursor bound to the same table and transaction (a nil
+// entry returns an error); these are the cursors that get positioned.
 //
 // deepness selects the B-tree level at which the distribution is computed: for
 // the positions to match a number of keys/values it must be at least the B-tree

--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -373,6 +373,16 @@ func (c *Cursor) RangeDel(mode uint) (numberAffected uint64, err error) {
 	return uint64(r.val), nil
 }
 
+// cptr returns c's underlying C cursor, or NULL when c is nil. The range/
+// distribution APIs accept a nil bound cursor to mean "the start/end of the
+// table", which maps to a NULL MDBX_cursor* on the C side.
+func cptr(c *Cursor) *C.MDBX_cursor {
+	if c == nil {
+		return nil
+	}
+	return c._c
+}
+
 // DeleteRange performs a mass deletion of the items between the position of the
 // receiver cursor (the beginning of the range) and the position of end (the end
 // of the range). It is much faster than deleting items one by one because whole
@@ -386,11 +396,7 @@ func (c *Cursor) RangeDel(mode uint) (numberAffected uint64, err error) {
 //
 // See mdbx_cursor_delete_range.
 func (c *Cursor) DeleteRange(end *Cursor, endIncluding bool) (numberAffected uint64, err error) {
-	var endC *C.MDBX_cursor
-	if end != nil {
-		endC = end._c
-	}
-	r := C.mdbxgo_cursor_delete_range(c._c, endC, C.bool(endIncluding))
+	r := C.mdbxgo_cursor_delete_range(c._c, cptr(end), C.bool(endIncluding))
 	if err := operrno("mdbx_cursor_delete_range", r.err); err != nil {
 		return 0, err
 	}
@@ -404,11 +410,7 @@ func (c *Cursor) DeleteRange(end *Cursor, endIncluding bool) (numberAffected uin
 //
 // See mdbx_estimate_distance.
 func (c *Cursor) EstimateDistance(last *Cursor) (int, error) {
-	var lastC *C.MDBX_cursor
-	if last != nil {
-		lastC = last._c
-	}
-	r := C.mdbxgo_estimate_distance(c._c, lastC)
+	r := C.mdbxgo_estimate_distance(c._c, cptr(last))
 	if err := operrno("mdbx_estimate_distance", r.err); err != nil {
 		return 0, err
 	}
@@ -457,11 +459,7 @@ func (c *Cursor) EstimateMove(key, data []byte, op uint) (int, error) {
 //
 // See mdbx_cursor_distance.
 func (c *Cursor) Distance(last *Cursor, deepness uint) (int, error) {
-	var lastC *C.MDBX_cursor
-	if last != nil {
-		lastC = last._c
-	}
-	r := C.mdbxgo_cursor_distance(c._c, lastC, C.unsigned(deepness))
+	r := C.mdbxgo_cursor_distance(c._c, cptr(last), C.unsigned(deepness))
 	if err := operrno("mdbx_cursor_distance", r.err); err != nil {
 		return 0, err
 	}
@@ -477,7 +475,7 @@ func (c *Cursor) Distance(last *Cursor, deepness uint) (int, error) {
 // nested height for DupSort tables); when in doubt pass a deliberately large
 // value such as 42.
 //
-// Scroll returns an error wrapping NotFound (see IsNotFound) if the end of the
+// Scroll returns an error for which IsNotFound reports true if the end of the
 // data is reached before the cursor moved by the full amount.
 //
 // See mdbx_cursor_scroll.
@@ -518,14 +516,7 @@ func DistributeCursors(first, last *Cursor, cursors []*Cursor, deepness uint) (a
 		}
 		arr[i] = cur._c
 	}
-	var firstC, lastC *C.MDBX_cursor
-	if first != nil {
-		firstC = first._c
-	}
-	if last != nil {
-		lastC = last._c
-	}
-	ret := C.mdbx_cursor_distribute(firstC, lastC, &arr[0], C.intptr_t(len(arr)), C.unsigned(deepness))
+	ret := C.mdbx_cursor_distribute(cptr(first), cptr(last), &arr[0], C.intptr_t(len(arr)), C.unsigned(deepness))
 	if ret == C.MDBX_RESULT_TRUE {
 		// Not enough positions in the range to set every cursor; the surplus
 		// cursors are left at EOF. operrno treats MDBX_RESULT_TRUE as success,

--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -373,6 +373,171 @@ func (c *Cursor) RangeDel(mode uint) (numberAffected uint64, err error) {
 	return uint64(r.val), nil
 }
 
+// DeleteRange performs a mass deletion of the items between the position of the
+// receiver cursor (the beginning of the range) and the position of end (the end
+// of the range). It is much faster than deleting items one by one because whole
+// pages and branches are cut out of the B+ tree.
+//
+// Both cursors must already be positioned (see Cursor.Get) and bound to the same
+// table and write transaction. A nil end deletes up to the last item.
+// endIncluding controls whether the item at end's position is itself deleted.
+//
+// It returns the number of deleted items.
+//
+// See mdbx_cursor_delete_range.
+func (c *Cursor) DeleteRange(end *Cursor, endIncluding bool) (numberAffected uint64, err error) {
+	var endC *C.MDBX_cursor
+	if end != nil {
+		endC = end._c
+	}
+	r := C.mdbxgo_cursor_delete_range(c._c, endC, C.bool(endIncluding))
+	if err := operrno("mdbx_cursor_delete_range", r.err); err != nil {
+		return 0, err
+	}
+	return uint64(r.val), nil
+}
+
+// EstimateDistance estimates the number of elements between the position of the
+// receiver cursor and the position of last. Both cursors must be positioned and
+// initialized for the same table and transaction. The result is a rough estimate
+// suitable for building/optimizing query plans, not an exact count.
+//
+// See mdbx_estimate_distance.
+func (c *Cursor) EstimateDistance(last *Cursor) (int, error) {
+	var lastC *C.MDBX_cursor
+	if last != nil {
+		lastC = last._c
+	}
+	r := C.mdbxgo_estimate_distance(c._c, lastC)
+	if err := operrno("mdbx_estimate_distance", r.err); err != nil {
+		return 0, err
+	}
+	return int(r.val), nil
+}
+
+// EstimateMove estimates the distance, as a number of elements, that the cursor
+// would move if the given key/data + op were applied via Get. The cursor's own
+// position and state are left unchanged. The result is a rough estimate suitable
+// for building/optimizing query plans, not an exact count.
+//
+// key/data are interpreted the same way as in Get for the given op; pass nil
+// where the op does not require them.
+//
+// See mdbx_estimate_move.
+func (c *Cursor) EstimateMove(key, data []byte, op uint) (int, error) {
+	var k, d *C.char
+	if len(key) > 0 {
+		k = (*C.char)(unsafe.Pointer(&key[0]))
+	}
+	if len(data) > 0 {
+		d = (*C.char)(unsafe.Pointer(&data[0]))
+	}
+	r := C.mdbxgo_estimate_move(
+		c._c,
+		k, C.size_t(len(key)),
+		d, C.size_t(len(data)),
+		C.MDBX_cursor_op(op),
+	)
+	if err := operrno("mdbx_estimate_move", r.err); err != nil {
+		return 0, err
+	}
+	return int(r.val), nil
+}
+
+// Distance calculates the number of elements between the position of the
+// receiver cursor and the position of last. Both cursors must be positioned and
+// bound to the same table and transaction; a nil last means the end of the
+// table.
+//
+// deepness limits the B-tree level at which the difference is measured: 0 is the
+// root (fast but rough), larger values descend toward the leaves (slower but
+// exact). For an exact count deepness must be at least the B-tree height (plus
+// the nested height for DupSort tables); when in doubt pass a deliberately large
+// value such as 42.
+//
+// See mdbx_cursor_distance.
+func (c *Cursor) Distance(last *Cursor, deepness uint) (int, error) {
+	var lastC *C.MDBX_cursor
+	if last != nil {
+		lastC = last._c
+	}
+	r := C.mdbxgo_cursor_distance(c._c, lastC, C.unsigned(deepness))
+	if err := operrno("mdbx_cursor_distance", r.err); err != nil {
+		return 0, err
+	}
+	return int(r.val), nil
+}
+
+// Scroll moves the cursor by amount logical positions at the given B-tree level.
+// A positive amount moves forward (toward the end of the table), a negative one
+// moves backward. The cursor must already be positioned.
+//
+// deepness selects the B-tree level the steps are taken at: for the movement to
+// match a number of keys/values it must be at least the B-tree height (plus the
+// nested height for DupSort tables); when in doubt pass a deliberately large
+// value such as 42.
+//
+// Scroll returns an error wrapping NotFound (see IsNotFound) if the end of the
+// data is reached before the cursor moved by the full amount.
+//
+// See mdbx_cursor_scroll.
+func (c *Cursor) Scroll(amount int, deepness uint) error {
+	ret := C.mdbx_cursor_scroll(c._c, C.intptr_t(amount), C.unsigned(deepness))
+	return operrno("mdbx_cursor_scroll", ret)
+}
+
+// DistributeCursors positions each cursor in cursors at an evenly-spaced
+// position across the range delimited by first and last, so that consecutive
+// cursors delimit approximately equally-sized sub-ranges. This is the intended
+// primitive for splitting a key range into balanced chunks for parallel workers
+// (e.g. concurrent range deletion or warm-up).
+//
+// A nil first means the beginning of the table and a nil last means the end;
+// at least one of them must be non-nil and positioned. All cursors must be bound
+// to the same table and transaction. cursors must contain at least one cursor
+// that is neither first nor last.
+//
+// deepness selects the B-tree level at which the distribution is computed: for
+// the positions to match a number of keys/values it must be at least the B-tree
+// height (plus the nested height for DupSort tables); when in doubt pass a
+// deliberately large value such as 42.
+//
+// allSet reports whether every cursor was positioned. It is false (with a nil
+// error) when the range held fewer positions than len(cursors); the surplus
+// cursors are left unset (at EOF).
+//
+// See mdbx_cursor_distribute.
+func DistributeCursors(first, last *Cursor, cursors []*Cursor, deepness uint) (allSet bool, err error) {
+	if len(cursors) == 0 {
+		return false, errors.New("mdbx: DistributeCursors requires at least one cursor")
+	}
+	arr := make([]*C.MDBX_cursor, len(cursors))
+	for i, cur := range cursors {
+		if cur == nil || cur._c == nil {
+			return false, errors.New("mdbx: DistributeCursors got a nil cursor")
+		}
+		arr[i] = cur._c
+	}
+	var firstC, lastC *C.MDBX_cursor
+	if first != nil {
+		firstC = first._c
+	}
+	if last != nil {
+		lastC = last._c
+	}
+	ret := C.mdbx_cursor_distribute(firstC, lastC, &arr[0], C.intptr_t(len(arr)), C.unsigned(deepness))
+	if ret == C.MDBX_RESULT_TRUE {
+		// Not enough positions in the range to set every cursor; the surplus
+		// cursors are left at EOF. operrno treats MDBX_RESULT_TRUE as success,
+		// so this case is reported via allSet rather than err.
+		return false, nil
+	}
+	if err := operrno("mdbx_cursor_distribute", ret); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // Count returns the number of duplicates for the current key.
 //
 // See mdb_cursor_count.

--- a/mdbx/mdbxgo.c
+++ b/mdbx/mdbxgo.c
@@ -137,6 +137,50 @@ mdbxgo_u64_result mdbxgo_cursor_bunch_delete(MDBX_cursor *cur, MDBX_bunch_action
     return r;
 }
 
+mdbxgo_u64_result mdbxgo_cursor_delete_range(MDBX_cursor *begin, MDBX_cursor *end, bool end_including) {
+    mdbxgo_u64_result r = {0};
+    r.err = mdbx_cursor_delete_range(begin, end, end_including, &r.val);
+    return r;
+}
+
+mdbxgo_ptrdiff_result mdbxgo_estimate_distance(const MDBX_cursor *first, const MDBX_cursor *last) {
+    mdbxgo_ptrdiff_result r = {0};
+    r.err = mdbx_estimate_distance(first, last, &r.val);
+    return r;
+}
+
+mdbxgo_ptrdiff_result mdbxgo_cursor_distance(const MDBX_cursor *first, const MDBX_cursor *last, unsigned deepness) {
+    mdbxgo_ptrdiff_result r = {0};
+    intptr_t d = 0;
+    r.err = mdbx_cursor_distance(first, last, &d, deepness);
+    r.val = d;
+    return r;
+}
+
+mdbxgo_ptrdiff_result mdbxgo_estimate_move(MDBX_cursor *cur, char *kdata, size_t kn, char *vdata, size_t vn, MDBX_cursor_op move_op) {
+    mdbxgo_ptrdiff_result r = {0};
+    MDBX_val key, data;
+    MDBX_val *k = NULL, *d = NULL;
+    if (kdata) { MDBXGO_SET_VAL(&key, kn, kdata); k = &key; }
+    if (vdata) { MDBXGO_SET_VAL(&data, vn, vdata); d = &data; }
+    r.err = mdbx_estimate_move(cur, k, d, move_op, &r.val);
+    return r;
+}
+
+mdbxgo_ptrdiff_result mdbxgo_estimate_range(MDBX_txn *txn, MDBX_dbi dbi,
+                                            char *begin_kdata, size_t begin_kn, char *begin_vdata, size_t begin_vn,
+                                            char *end_kdata, size_t end_kn, char *end_vdata, size_t end_vn) {
+    mdbxgo_ptrdiff_result r = {0};
+    MDBX_val begin_key, begin_data, end_key, end_data;
+    MDBX_val *bk = NULL, *bd = NULL, *ek = NULL, *ed = NULL;
+    if (begin_kdata) { MDBXGO_SET_VAL(&begin_key, begin_kn, begin_kdata); bk = &begin_key; }
+    if (begin_vdata) { MDBXGO_SET_VAL(&begin_data, begin_vn, begin_vdata); bd = &begin_data; }
+    if (end_kdata)   { MDBXGO_SET_VAL(&end_key, end_kn, end_kdata);       ek = &end_key; }
+    if (end_vdata)   { MDBXGO_SET_VAL(&end_data, end_vn, end_vdata);       ed = &end_data; }
+    r.err = mdbx_estimate_range(txn, dbi, bk, bd, ek, ed, &r.val);
+    return r;
+}
+
 mdbxgo_u64_result mdbxgo_dbi_sequence(MDBX_txn *txn, MDBX_dbi dbi, uint64_t increment) {
     mdbxgo_u64_result r = {0};
     r.err = mdbx_dbi_sequence(txn, dbi, &r.val, increment);

--- a/mdbx/mdbxgo.h
+++ b/mdbx/mdbxgo.h
@@ -45,14 +45,20 @@ int mdbxgo_dcmp(MDBX_txn *txn, MDBX_dbi dbi, char *adata, size_t an, char *bdata
 /* The mdbxgo_*_result structs bundle an error code with a scalar return value
  * so that helper functions can return both without taking a Go pointer as an
  * out-parameter (which would escape the Go variable to the heap). */
-typedef struct { int err; size_t   val; } mdbxgo_size_result;
-typedef struct { int err; uint64_t val; } mdbxgo_u64_result;
-typedef struct { int err; unsigned val; } mdbxgo_uint_result;
-typedef struct { int err; int      val; } mdbxgo_int_result;
+typedef struct { int err; size_t    val; } mdbxgo_size_result;
+typedef struct { int err; uint64_t  val; } mdbxgo_u64_result;
+typedef struct { int err; unsigned  val; } mdbxgo_uint_result;
+typedef struct { int err; int       val; } mdbxgo_int_result;
+typedef struct { int err; ptrdiff_t val; } mdbxgo_ptrdiff_result;
 typedef struct { int err; intptr_t pageSize, totalPages, availPages; } mdbxgo_sysraminfo_result;
 
 mdbxgo_size_result       mdbxgo_cursor_count(MDBX_cursor *cur);
 mdbxgo_u64_result        mdbxgo_cursor_bunch_delete(MDBX_cursor *cur, MDBX_bunch_action_t mode);
+mdbxgo_u64_result        mdbxgo_cursor_delete_range(MDBX_cursor *begin, MDBX_cursor *end, bool end_including);
+mdbxgo_ptrdiff_result    mdbxgo_estimate_distance(const MDBX_cursor *first, const MDBX_cursor *last);
+mdbxgo_ptrdiff_result    mdbxgo_cursor_distance(const MDBX_cursor *first, const MDBX_cursor *last, unsigned deepness);
+mdbxgo_ptrdiff_result    mdbxgo_estimate_move(MDBX_cursor *cur, char *kdata, size_t kn, char *vdata, size_t vn, MDBX_cursor_op move_op);
+mdbxgo_ptrdiff_result    mdbxgo_estimate_range(MDBX_txn *txn, MDBX_dbi dbi, char *begin_kdata, size_t begin_kn, char *begin_vdata, size_t begin_vn, char *end_kdata, size_t end_kn, char *end_vdata, size_t end_vn);
 mdbxgo_u64_result        mdbxgo_dbi_sequence(MDBX_txn *txn, MDBX_dbi dbi, uint64_t increment);
 mdbxgo_u64_result        mdbxgo_env_get_option(MDBX_env *env, MDBX_option_t option);
 mdbxgo_uint_result       mdbxgo_env_get_syncperiod(MDBX_env *env);

--- a/mdbx/range_test.go
+++ b/mdbx/range_test.go
@@ -323,6 +323,8 @@ func TestDistributeCursors(t *testing.T) {
 			if !allSet {
 				t.Fatalf("allSet=false for sub-range [%d,%d]", lo, hi)
 			}
+			chunk := (hi - lo) / len(cursors)
+			tol := chunk/2 + 2
 			prev := lo
 			for i, c := range cursors {
 				pos, ok := curKeyInt(c)
@@ -331,6 +333,11 @@ func TestDistributeCursors(t *testing.T) {
 				}
 				if pos <= prev || pos > hi {
 					t.Fatalf("cursor %d pos=%d not in (%d,%d]", i, pos, prev, hi)
+				}
+				// Chunks within the explicit bounds must be balanced too, not just
+				// monotonic (guards against cursors bunching at one end).
+				if abs(pos-prev-chunk) > tol {
+					t.Fatalf("cursor %d chunk size=%d, want ~%d (tol %d)", i, pos-prev, chunk, tol)
 				}
 				prev = pos
 			}
@@ -380,8 +387,10 @@ func TestDistributeCursors(t *testing.T) {
 				}
 				prev = pos
 			}
-			if set == 0 || set > n {
-				t.Fatalf("positioned %d cursors, want 1..%d", set, n)
+			// first occupies key 0, leaving keys 1..n-1 as the only boundary
+			// positions, so exactly n-1 cursors can be set; the rest stay unset.
+			if set != n-1 {
+				t.Fatalf("positioned %d cursors, want %d", set, n-1)
 			}
 			return nil
 		}); err != nil {

--- a/mdbx/range_test.go
+++ b/mdbx/range_test.go
@@ -1,0 +1,599 @@
+package mdbx
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// mustPutSeqBE inserts n keys 0..n-1 as 4-byte big-endian (so they sort
+// numerically) with an identical value, into a freshly created unique DB.
+func mustPutSeqBE(t *testing.T, env *Env, name string, n int) DBI {
+	t.Helper()
+	db := mustOpenUniqueDB(t, env, name)
+	if err := env.Update(func(txn *Txn) error {
+		var kb [4]byte
+		for i := 0; i < n; i++ {
+			binary.BigEndian.PutUint32(kb[:], uint32(i))
+			if err := txn.Put(db, kb[:], kb[:], 0); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("put seq be: %v", err)
+	}
+	return db
+}
+
+func beKey(i uint32) []byte {
+	var kb [4]byte
+	binary.BigEndian.PutUint32(kb[:], i)
+	return kb[:]
+}
+
+func TestTxn_EstimateRange(t *testing.T) {
+	env, _ := setup(t)
+	const n = 5000
+	db := mustPutSeqBE(t, env, "estimate_range", n)
+
+	if err := env.View(func(txn *Txn) error {
+		// Whole table: nil begin + nil end.
+		total, err := txn.EstimateRange(db, nil, nil, nil, nil)
+		if err != nil {
+			return err
+		}
+		// Rough estimate: must be in the right ballpark.
+		if total < n/2 || total > n*2 {
+			t.Fatalf("full-range estimate=%d, want ~%d", total, n)
+		}
+
+		// A half-open sub-range must be positive and not exceed the total.
+		half, err := txn.EstimateRange(db, beKey(1000), nil, beKey(3000), nil)
+		if err != nil {
+			return err
+		}
+		if half <= 0 || half > total {
+			t.Fatalf("sub-range estimate=%d, want in (0,%d]", half, total)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCursor_EstimateDistanceAndDistance(t *testing.T) {
+	env, _ := setup(t)
+	const n = 1000
+	db := mustPutSeqBE(t, env, "estimate_distance", n)
+
+	if err := env.View(func(txn *Txn) error {
+		first, err := txn.OpenCursor(db)
+		if err != nil {
+			return err
+		}
+		defer first.Close()
+		last, err := txn.OpenCursor(db)
+		if err != nil {
+			return err
+		}
+		defer last.Close()
+
+		if _, _, err := first.Get(beKey(100), nil, SetKey); err != nil {
+			return err
+		}
+		if _, _, err := last.Get(beKey(900), nil, SetKey); err != nil {
+			return err
+		}
+
+		// Exact distance with a large deepness.
+		d, err := first.Distance(last, 42)
+		if err != nil {
+			return err
+		}
+		if d != 800 && d != -800 {
+			t.Fatalf("Distance=%d, want ±800", d)
+		}
+
+		// Rough estimate should be in the ballpark.
+		ed, err := first.EstimateDistance(last)
+		if err != nil {
+			return err
+		}
+		if ed < 400 || ed > 1200 {
+			t.Fatalf("EstimateDistance=%d, want ~800", ed)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCursor_EstimateMove(t *testing.T) {
+	env, _ := setup(t)
+	const n = 1000
+	db := mustPutSeqBE(t, env, "estimate_move", n)
+
+	if err := env.View(func(txn *Txn) error {
+		cur, err := txn.OpenCursor(db)
+		if err != nil {
+			return err
+		}
+		defer cur.Close()
+
+		if _, _, err := cur.Get(nil, nil, First); err != nil {
+			return err
+		}
+		// Estimate the move from First to Last; should be close to n.
+		d, err := cur.EstimateMove(nil, nil, Last)
+		if err != nil {
+			return err
+		}
+		if d < n/2 || d > n*2 {
+			t.Fatalf("EstimateMove(Last)=%d, want ~%d", d, n)
+		}
+		// The cursor must not have moved.
+		k, _, err := cur.Get(nil, nil, GetCurrent)
+		if err != nil {
+			return err
+		}
+		if binary.BigEndian.Uint32(k) != 0 {
+			t.Fatalf("cursor moved after EstimateMove: key=%d", binary.BigEndian.Uint32(k))
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCursor_Scroll(t *testing.T) {
+	env, _ := setup(t)
+	const n = 100
+	db := mustPutSeqBE(t, env, "scroll", n)
+
+	if err := env.View(func(txn *Txn) error {
+		cur, err := txn.OpenCursor(db)
+		if err != nil {
+			return err
+		}
+		defer cur.Close()
+
+		if _, _, err := cur.Get(nil, nil, First); err != nil {
+			return err
+		}
+		if err := cur.Scroll(5, 42); err != nil {
+			return err
+		}
+		k, _, err := cur.Get(nil, nil, GetCurrent)
+		if err != nil {
+			return err
+		}
+		if got := binary.BigEndian.Uint32(k); got != 5 {
+			t.Fatalf("after Scroll(+5) key=%d, want 5", got)
+		}
+
+		if err := cur.Scroll(-2, 42); err != nil {
+			return err
+		}
+		k, _, err = cur.Get(nil, nil, GetCurrent)
+		if err != nil {
+			return err
+		}
+		if got := binary.BigEndian.Uint32(k); got != 3 {
+			t.Fatalf("after Scroll(-2) key=%d, want 3", got)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// curKeyInt returns the current cursor key decoded as a uint32, and ok=false if
+// the cursor is not positioned on any data (e.g. an unset cursor after a partial
+// DistributeCursors).
+func curKeyInt(c *Cursor) (int, bool) {
+	k, _, err := c.Get(nil, nil, GetCurrent)
+	if err != nil || len(k) != 4 {
+		return 0, false
+	}
+	return int(binary.BigEndian.Uint32(k)), true
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// openCursors opens count cursors on db within txn (each closed via t.Cleanup).
+func openCursors(t *testing.T, txn *Txn, db DBI, count int) []*Cursor {
+	t.Helper()
+	cursors := make([]*Cursor, count)
+	for i := range cursors {
+		c, err := txn.OpenCursor(db)
+		if err != nil {
+			t.Fatalf("OpenCursor: %v", err)
+		}
+		cursors[i] = c
+	}
+	return cursors
+}
+
+func TestDistributeCursors(t *testing.T) {
+	// Even distribution over the whole table for several worker counts. Keys are
+	// dense (0..n-1), so a key's integer value equals its rank, which lets us
+	// assert that consecutive cursors delimit approximately equally-sized chunks.
+	t.Run("even", func(t *testing.T) {
+		env, _ := setup(t)
+		const n = 1000
+		db := mustPutSeqBE(t, env, "distribute_even", n)
+
+		for _, workers := range []int{1, 2, 3, 4, 7, 8} {
+			if err := env.View(func(txn *Txn) error {
+				first := openCursors(t, txn, db, 1)[0]
+				defer first.Close()
+				if _, _, err := first.Get(nil, nil, First); err != nil {
+					return err
+				}
+				cursors := openCursors(t, txn, db, workers)
+				for _, c := range cursors {
+					defer c.Close()
+				}
+
+				allSet, err := DistributeCursors(first, nil, cursors, 42)
+				if err != nil {
+					return err
+				}
+				if !allSet {
+					t.Fatalf("workers=%d: allSet=false over %d keys", workers, n)
+				}
+
+				chunk := n / workers
+				tol := chunk/2 + 2 // generous: page boundaries may shift positions
+				prev := -1
+				prevPos := 0 // first cursor's range starts at rank 0
+				for i, c := range cursors {
+					pos, ok := curKeyInt(c)
+					if !ok {
+						t.Fatalf("workers=%d: cursor %d not positioned", workers, i)
+					}
+					if pos <= prev {
+						t.Fatalf("workers=%d: cursor %d pos=%d not > prev=%d", workers, i, pos, prev)
+					}
+					if pos < 0 || pos >= n {
+						t.Fatalf("workers=%d: cursor %d pos=%d out of [0,%d)", workers, i, pos, n)
+					}
+					// Cursor i marks the upper boundary of chunk i, expected near
+					// (i+1)*n/workers (the final cursor lands on the last key).
+					want := (i + 1) * n / workers
+					if i == workers-1 {
+						want = n - 1
+					}
+					if abs(pos-want) > tol {
+						t.Fatalf("workers=%d: cursor %d pos=%d, want ~%d (tol %d)", workers, i, pos, want, tol)
+					}
+					// Chunk size between boundaries must be balanced.
+					size := pos - prevPos
+					if abs(size-chunk) > tol {
+						t.Fatalf("workers=%d: chunk %d size=%d, want ~%d (tol %d)", workers, i, size, chunk, tol)
+					}
+					prev = pos
+					prevPos = pos
+				}
+				// Last cursor must reach the final key so the whole range is covered.
+				if prev != n-1 {
+					t.Fatalf("workers=%d: last cursor at %d, want %d", workers, prev, n-1)
+				}
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+
+	// Distribution constrained to an explicit [first, last] sub-range.
+	t.Run("explicit-bounds", func(t *testing.T) {
+		env, _ := setup(t)
+		const n = 1000
+		const lo, hi = 200, 800
+		db := mustPutSeqBE(t, env, "distribute_bounds", n)
+
+		if err := env.View(func(txn *Txn) error {
+			bounds := openCursors(t, txn, db, 2)
+			first, last := bounds[0], bounds[1]
+			defer first.Close()
+			defer last.Close()
+			if _, _, err := first.Get(beKey(lo), nil, SetKey); err != nil {
+				return err
+			}
+			if _, _, err := last.Get(beKey(hi), nil, SetKey); err != nil {
+				return err
+			}
+
+			cursors := openCursors(t, txn, db, 3)
+			for _, c := range cursors {
+				defer c.Close()
+			}
+			allSet, err := DistributeCursors(first, last, cursors, 42)
+			if err != nil {
+				return err
+			}
+			if !allSet {
+				t.Fatalf("allSet=false for sub-range [%d,%d]", lo, hi)
+			}
+			prev := lo
+			for i, c := range cursors {
+				pos, ok := curKeyInt(c)
+				if !ok {
+					t.Fatalf("cursor %d not positioned", i)
+				}
+				if pos <= prev || pos > hi {
+					t.Fatalf("cursor %d pos=%d not in (%d,%d]", i, pos, prev, hi)
+				}
+				prev = pos
+			}
+			if prev != hi {
+				t.Fatalf("last cursor at %d, want %d", prev, hi)
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// More cursors than available positions: allSet must be false (with nil
+	// error), only the first few cursors get positioned, and they stay valid.
+	t.Run("not-enough-positions", func(t *testing.T) {
+		env, _ := setup(t)
+		const n = 3
+		db := mustPutSeqBE(t, env, "distribute_small", n)
+
+		if err := env.View(func(txn *Txn) error {
+			first := openCursors(t, txn, db, 1)[0]
+			defer first.Close()
+			if _, _, err := first.Get(nil, nil, First); err != nil {
+				return err
+			}
+			cursors := openCursors(t, txn, db, 8)
+			for _, c := range cursors {
+				defer c.Close()
+			}
+
+			allSet, err := DistributeCursors(first, nil, cursors, 42)
+			if err != nil {
+				return err
+			}
+			if allSet {
+				t.Fatalf("allSet=true, want false (only %d keys, 8 cursors)", n)
+			}
+			set, prev := 0, -1
+			for _, c := range cursors {
+				pos, ok := curKeyInt(c)
+				if !ok {
+					continue
+				}
+				set++
+				if pos <= prev {
+					t.Fatalf("positioned cursor pos=%d not > prev=%d", pos, prev)
+				}
+				prev = pos
+			}
+			if set == 0 || set > n {
+				t.Fatalf("positioned %d cursors, want 1..%d", set, n)
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Using distributed boundaries to delete the whole table in balanced chunks,
+	// the way parallel workers would. Validates the end-to-end workflow:
+	// distribute -> per-chunk DeleteRange -> full coverage, no gaps/overlaps.
+	t.Run("delete-in-chunks", func(t *testing.T) {
+		env, _ := setup(t)
+		const n = 1000
+		const workers = 4
+		db := mustPutSeqBE(t, env, "distribute_delete", n)
+
+		// 1) Read-only: compute the worker boundary keys.
+		var bounds [][]byte
+		if err := env.View(func(txn *Txn) error {
+			first := openCursors(t, txn, db, 1)[0]
+			defer first.Close()
+			if _, _, err := first.Get(nil, nil, First); err != nil {
+				return err
+			}
+			cursors := openCursors(t, txn, db, workers)
+			for _, c := range cursors {
+				defer c.Close()
+			}
+			allSet, err := DistributeCursors(first, nil, cursors, 42)
+			if err != nil {
+				return err
+			}
+			if !allSet {
+				t.Fatalf("allSet=false")
+			}
+			for _, c := range cursors {
+				pos, ok := curKeyInt(c)
+				if !ok {
+					t.Fatalf("cursor not positioned")
+				}
+				bounds = append(bounds, beKey(uint32(pos)))
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		// 2) Write: each worker deletes its chunk. Chunk 0 covers [start,bounds[0]]
+		// and chunk i covers (bounds[i-1], bounds[i]] (boundary inclusive). Chunks
+		// are processed back-to-front so that a boundary key is never looked up
+		// after an earlier chunk already deleted it.
+		deleteChunk := func(txn *Txn, i int) (uint64, error) {
+			begin, err := txn.OpenCursor(db)
+			if err != nil {
+				return 0, err
+			}
+			defer begin.Close()
+			end, err := txn.OpenCursor(db)
+			if err != nil {
+				return 0, err
+			}
+			defer end.Close()
+
+			if i == 0 {
+				if _, _, err := begin.Get(nil, nil, First); err != nil {
+					return 0, err
+				}
+			} else {
+				// Position at the previous boundary, then step to the first key
+				// strictly after it (the start of this chunk).
+				if _, _, err := begin.Get(bounds[i-1], nil, SetKey); err != nil {
+					return 0, err
+				}
+				if _, _, err := begin.Get(nil, nil, Next); err != nil {
+					return 0, err
+				}
+			}
+			if _, _, err := end.Get(bounds[i], nil, SetKey); err != nil {
+				return 0, err
+			}
+			return begin.DeleteRange(end, true) // inclusive of the boundary key
+		}
+
+		var total uint64
+		if err := env.Update(func(txn *Txn) error {
+			for i := len(bounds) - 1; i >= 0; i-- {
+				affected, err := deleteChunk(txn, i)
+				if err != nil {
+					return err
+				}
+				total += affected
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		if total != n {
+			t.Fatalf("deleted %d items across chunks, want %d", total, n)
+		}
+		if got := dumpAll(t, env, db); len(got) != 0 {
+			t.Fatalf("table not empty after chunked delete: %d keys remain", len(got))
+		}
+	})
+
+	// Error and edge cases.
+	t.Run("errors", func(t *testing.T) {
+		env, _ := setup(t)
+		db := mustPutSeqBE(t, env, "distribute_errors", 10)
+
+		if err := env.View(func(txn *Txn) error {
+			first := openCursors(t, txn, db, 1)[0]
+			defer first.Close()
+			if _, _, err := first.Get(nil, nil, First); err != nil {
+				return err
+			}
+
+			// Empty cursors slice.
+			if _, err := DistributeCursors(first, nil, nil, 42); err == nil {
+				t.Fatalf("expected error for empty cursors slice")
+			}
+
+			// Nil cursor inside the slice.
+			c0 := openCursors(t, txn, db, 1)[0]
+			defer c0.Close()
+			if _, err := DistributeCursors(first, nil, []*Cursor{c0, nil}, 42); err == nil {
+				t.Fatalf("expected error for nil cursor in slice")
+			}
+
+			// Both bounds nil is invalid per mdbx.
+			c1 := openCursors(t, txn, db, 1)[0]
+			defer c1.Close()
+			if _, err := DistributeCursors(nil, nil, []*Cursor{c1}, 42); err == nil {
+				t.Fatalf("expected error when both first and last are nil")
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestCursor_DeleteRange(t *testing.T) {
+	t.Run("whole", func(t *testing.T) {
+		env, _ := setup(t)
+		db := mustPutUniqueSeq2(t, env, "delrange_whole", 10)
+		var affected uint64
+		if err := env.Update(func(txn *Txn) error {
+			begin, err := txn.OpenCursor(db)
+			if err != nil {
+				return err
+			}
+			defer begin.Close()
+			if _, _, err := begin.Get(nil, nil, First); err != nil {
+				return err
+			}
+			affected, err = begin.DeleteRange(nil, true) // begin..last inclusive
+			return err
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if affected != 10 {
+			t.Fatalf("affected=%d, want 10", affected)
+		}
+		if got := dumpAll(t, env, db); len(got) != 0 {
+			t.Fatalf("remaining=%v, want empty", got)
+		}
+	})
+
+	t.Run("partial-excluding", func(t *testing.T) {
+		env, _ := setup(t)
+		db := mustPutUniqueSeq2(t, env, "delrange_partial", 10)
+		var affected uint64
+		if err := env.Update(func(txn *Txn) error {
+			begin, err := txn.OpenCursor(db)
+			if err != nil {
+				return err
+			}
+			defer begin.Close()
+			end, err := txn.OpenCursor(db)
+			if err != nil {
+				return err
+			}
+			defer end.Close()
+
+			if _, _, err := begin.Get([]byte("k2"), nil, SetKey); err != nil {
+				return err
+			}
+			if _, _, err := end.Get([]byte("k7"), nil, SetKey); err != nil {
+				return err
+			}
+			affected, err = begin.DeleteRange(end, false) // [k2, k7)
+			return err
+		}); err != nil {
+			t.Fatal(err)
+		}
+		remaining := dumpAll(t, env, db)
+		if uint64(10-len(remaining)) != affected {
+			t.Fatalf("affected=%d but %d keys removed", affected, 10-len(remaining))
+		}
+		// [k2,k7) excluding => k2..k6 removed (5), keep k0,k1,k7,k8,k9.
+		if affected != 5 {
+			t.Fatalf("affected=%d, want 5; remaining=%v", affected, remaining)
+		}
+		requireEqual(t, remaining, []kv{
+			{"k0", "v0"}, {"k1", "v1"}, {"k7", "v7"}, {"k8", "v8"}, {"k9", "v9"},
+		})
+	})
+}
+
+// mustPutUniqueSeq2 is mustPutUniqueSeq but returns the created DBI.
+func mustPutUniqueSeq2(t *testing.T, env *Env, name string, n int) DBI {
+	t.Helper()
+	db := mustOpenUniqueDB(t, env, name)
+	mustPutUniqueSeq(t, env, db, n)
+	return db
+}

--- a/mdbx/range_test.go
+++ b/mdbx/range_test.go
@@ -85,13 +85,23 @@ func TestCursor_EstimateDistanceAndDistance(t *testing.T) {
 			return err
 		}
 
-		// Exact distance with a large deepness.
+		// Exact distance with a large deepness. first (key 100) precedes last
+		// (key 900), so the forward distance is exactly +800; the sign is
+		// deterministic and a sign-inversion regression must be caught.
 		d, err := first.Distance(last, 42)
 		if err != nil {
 			return err
 		}
-		if d != 800 && d != -800 {
-			t.Fatalf("Distance=%d, want ±800", d)
+		if d != 800 {
+			t.Fatalf("Distance(100->900)=%d, want 800", d)
+		}
+		// Reversed cursors yield the negated distance.
+		dRev, err := last.Distance(first, 42)
+		if err != nil {
+			return err
+		}
+		if dRev != -800 {
+			t.Fatalf("Distance(900->100)=%d, want -800", dRev)
 		}
 
 		// Rough estimate should be in the ballpark.
@@ -132,12 +142,12 @@ func TestCursor_EstimateMove(t *testing.T) {
 			t.Fatalf("EstimateMove(Last)=%d, want ~%d", d, n)
 		}
 		// The cursor must not have moved.
-		k, _, err := cur.Get(nil, nil, GetCurrent)
-		if err != nil {
-			return err
+		pos, ok := curKeyInt(cur)
+		if !ok {
+			t.Fatalf("cursor not positioned after EstimateMove")
 		}
-		if binary.BigEndian.Uint32(k) != 0 {
-			t.Fatalf("cursor moved after EstimateMove: key=%d", binary.BigEndian.Uint32(k))
+		if pos != 0 {
+			t.Fatalf("cursor moved after EstimateMove: key=%d", pos)
 		}
 		return nil
 	}); err != nil {
@@ -163,23 +173,15 @@ func TestCursor_Scroll(t *testing.T) {
 		if err := cur.Scroll(5, 42); err != nil {
 			return err
 		}
-		k, _, err := cur.Get(nil, nil, GetCurrent)
-		if err != nil {
-			return err
-		}
-		if got := binary.BigEndian.Uint32(k); got != 5 {
-			t.Fatalf("after Scroll(+5) key=%d, want 5", got)
+		if got, ok := curKeyInt(cur); !ok || got != 5 {
+			t.Fatalf("after Scroll(+5) key=%d ok=%v, want 5", got, ok)
 		}
 
 		if err := cur.Scroll(-2, 42); err != nil {
 			return err
 		}
-		k, _, err = cur.Get(nil, nil, GetCurrent)
-		if err != nil {
-			return err
-		}
-		if got := binary.BigEndian.Uint32(k); got != 3 {
-			t.Fatalf("after Scroll(-2) key=%d, want 3", got)
+		if got, ok := curKeyInt(cur); !ok || got != 3 {
+			t.Fatalf("after Scroll(-2) key=%d ok=%v, want 3", got, ok)
 		}
 		return nil
 	}); err != nil {

--- a/mdbx/txn.go
+++ b/mdbx/txn.go
@@ -1108,6 +1108,43 @@ func (txn *Txn) DCmp(dbi DBI, a []byte, b []byte) int {
 	return 0
 }
 
+// EstimateRange estimates, as a number of elements, the size of the key range
+// that starts at beginKey and ends at endKey. The result is a rough estimate
+// based on the b-tree structure, intended for building and optimizing query
+// plans (e.g. splitting a key range into evenly-sized chunks for parallel
+// workers); it is not an exact count.
+//
+// A nil beginKey means the range starts at the first item of dbi; a nil endKey
+// means it ends at the last item. beginData/endData are only meaningful for
+// DupSort databases (pass nil otherwise) and may only be supplied together with
+// the corresponding key.
+//
+// See mdbx_estimate_range.
+func (txn *Txn) EstimateRange(dbi DBI, beginKey, beginData, endKey, endData []byte) (int, error) {
+	var bk, bd, ek, ed *C.char
+	if len(beginKey) > 0 {
+		bk = (*C.char)(unsafe.Pointer(&beginKey[0]))
+	}
+	if len(beginData) > 0 {
+		bd = (*C.char)(unsafe.Pointer(&beginData[0]))
+	}
+	if len(endKey) > 0 {
+		ek = (*C.char)(unsafe.Pointer(&endKey[0]))
+	}
+	if len(endData) > 0 {
+		ed = (*C.char)(unsafe.Pointer(&endData[0]))
+	}
+	r := C.mdbxgo_estimate_range(
+		txn._txn, C.MDBX_dbi(dbi),
+		bk, C.size_t(len(beginKey)), bd, C.size_t(len(beginData)),
+		ek, C.size_t(len(endKey)), ed, C.size_t(len(endData)),
+	)
+	if err := operrno("mdbx_estimate_range", r.err); err != nil {
+		return 0, err
+	}
+	return int(r.val), nil
+}
+
 func (txn *Txn) Sequence(dbi DBI, increment uint64) (uint64, error) {
 	r := C.mdbxgo_dbi_sequence(txn._txn, C.MDBX_dbi(dbi), C.uint64_t(increment))
 	if r.err != success {


### PR DESCRIPTION
## What

Exposes the libmdbx **range-estimation** (`c_rqest`) and **B-tree cursor navigation** (`c_cursors`) groups. Motivation: split a key range into balanced chunks so multiple workers can process the same range in parallel (e.g. concurrent range deletion or background warm-up).

| Go API | libmdbx |
|---|---|
| `Txn.EstimateRange(dbi, beginKey, beginData, endKey, endData)` | `mdbx_estimate_range` |
| `Cursor.EstimateDistance(last)` | `mdbx_estimate_distance` |
| `Cursor.EstimateMove(key, data, op)` | `mdbx_estimate_move` |
| `Cursor.Distance(last, deepness)` | `mdbx_cursor_distance` (deepness-controlled, can be exact) |
| `Cursor.Scroll(amount, deepness)` | `mdbx_cursor_scroll` |
| `DistributeCursors(first, last, cursors, deepness)` | `mdbx_cursor_distribute` |
| `Cursor.DeleteRange(end, endIncluding)` | `mdbx_cursor_delete_range` |

## Equally-sized ranges for parallel workers

`DistributeCursors` is the key primitive for the use case: it positions N cursors at evenly-spaced positions across `[first, last]`, so consecutive cursors delimit approximately equal sub-ranges — no manual binary search over the key space needed. Cursor `i` lands on the upper boundary of chunk `i` (the last cursor on the final key of the range). When the range holds fewer positions than cursors, it returns `allSet=false` (with a nil error) and leaves the surplus cursors unset.

`Cursor.Distance` / `Txn.EstimateRange` let workers size/verify chunks; `Cursor.DeleteRange` does the fast mass deletion (cutting whole pages/branches out of the B+ tree).

Typical flow: position a `first` cursor (or pass `nil` for table start) → `DistributeCursors` with one cursor per worker → each worker gets a boundary key → each deletes its chunk with `Cursor.DeleteRange`.

## Implementation

- New C shims in `mdbxgo.{h,c}` returning `{err, value}` structs (new `mdbxgo_ptrdiff_result`) so out-params don't escape to the Go heap, matching the existing helper pattern.
- `mdbx_cursor_distribute` / `mdbx_cursor_scroll` are called directly (they return `int`); `distribute` handles `MDBX_RESULT_TRUE` explicitly since `operrno` treats it as success, surfacing it as `allSet=false`.
- `cptr()` helper collapses the repeated nil-cursor → `NULL` unwrap shared by the new cursor APIs.

## Tests

`mdbx/range_test.go` covers every new function. `DistributeCursors` (the complex one) has dedicated subtests: even distribution across several worker counts (asserting balanced chunk sizes), explicit `[first,last]` bounds (also balance-checked), the not-enough-positions case (`allSet=false`, exactly `n-1` cursors set), an end-to-end **distribute → per-chunk DeleteRange → full coverage** workflow, and error/edge cases.

## Review pass

A high-effort review was run on the diff. Outcome:
- No correctness bugs in the bindings: cgo pointer passing (the `[]*C.MDBX_cursor` array holds C pointers, pinned for the call), `ptrdiff_t`/`intptr_t` widths, `MDBX_RESULT_TRUE` handling, and NULL-vs-data semantics all check out.
- Applied fixes: extracted the `cptr()` helper, corrected the `Scroll` doc (returns the bare `ErrNotFound` sentinel — `IsNotFound` true — rather than a wrapped error), and tightened the new tests so regressions are actually caught (exact signed `Distance`, balanced-chunk assertions, exact set-count, panic-free key reads).
- Noted but not changed (consistent with the existing codebase-wide idiom, not regressions): empty-vs-nil byte slices both map to `NULL` (same as `Get`/`Put`/`Cmp`), and cursor methods don't guard a closed `_c` (same as `Del`/`RangeDel`/`Count`).

`go build`, `go vet`, and `go test ./mdbx/` all pass.