### PR TITLE
mdbx: doc fixes for EstimateDistance/DistributeCursors

### DIFF
--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -404,9 +404,11 @@ func (c *Cursor) DeleteRange(end *Cursor, endIncluding bool) (numberAffected uin
 }
 
 // EstimateDistance estimates the number of elements between the position of the
-// receiver cursor and the position of last. Both cursors must be positioned and
-// initialized for the same table and transaction. The result is a rough estimate
-// suitable for building/optimizing query plans, not an exact count.
+// receiver cursor and the position of last. Both cursors must be non-nil,
+// positioned, and initialized for the same table and transaction. Unlike
+// Distance, this estimate has no end-of-table sentinel: a nil last is not a
+// valid argument. The result is a rough estimate suitable for building/optimizing
+// query plans, not an exact count.
 //
 // See mdbx_estimate_distance.
 func (c *Cursor) EstimateDistance(last *Cursor) (int, error) {
@@ -491,9 +493,9 @@ func (c *Cursor) Scroll(amount int, deepness uint) error {
 // (e.g. concurrent range deletion or warm-up).
 //
 // A nil first means the beginning of the table and a nil last means the end;
-// at least one of them must be non-nil and positioned. All cursors must be bound
-// to the same table and transaction. cursors must contain at least one cursor
-// that is neither first nor last.
+// at least one of them must be non-nil and positioned. Every entry in cursors
+// must be a non-nil open cursor bound to the same table and transaction (a nil
+// entry returns an error); these are the cursors that get positioned.
 //
 // deepness selects the B-tree level at which the distribution is computed: for
 // the positions to match a number of keys/values it must be at least the B-tree


### PR DESCRIPTION
Doc-only fixes on top of #225, checked against `libmdbx/mdbx.h`.

- **`EstimateDistance`** — `mdbx_estimate_distance` (mdbx.h:6618) requires both cursors and, unlike `mdbx_cursor_distance`, has no NULL = end-of-table sentinel. The old doc didn't say nil `last` is invalid here, so it read as if it behaved like `Distance`. Now states both cursors must be non-nil and positioned.
- **`DistributeCursors`** — dropped the "cursors must contain at least one cursor that is neither first nor last" line. `mdbx_cursor_distribute` (mdbx.h:6401-6409) has no such requirement; the array is just the cursors to position. Replaced with the actual constraint (each entry must be a non-nil open cursor on the same table/txn).

No code or behavior change.
