### PR TITLE
mdbx: map MDBX_ENODATA to ErrNoData (hollow-cursor GET_CURRENT)

### DIFF
--- a/mdbx/cursor_test.go
+++ b/mdbx/cursor_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -2436,5 +2437,39 @@ func TestCursor_RangeDel_EmptyTable_DeleteWhole(t *testing.T) {
 
 	if affected != 0 {
 		t.Fatalf("affected=%d, want 0", affected)
+	}
+}
+
+// GET_CURRENT on a cursor that was never positioned (hollow) returns
+// MDBX_ENODATA, not MDBX_NOTFOUND. operrno must surface it as ErrNoData so
+// callers can tell "cursor not positioned" apart from "key not found".
+func TestCursor_GetCurrent_Hollow(t *testing.T) {
+	env, _ := setup(t)
+
+	if err := env.Update(func(txn *Txn) error {
+		db, err := txn.OpenDBISimple("db", Create)
+		if err != nil {
+			return err
+		}
+		if err := txn.Put(db, []byte("k"), []byte("v"), 0); err != nil {
+			return err
+		}
+
+		cur, err := txn.OpenCursor(db)
+		if err != nil {
+			return err
+		}
+		defer cur.Close()
+
+		_, _, err = cur.Get(nil, nil, GetCurrent)
+		if !IsNoData(err) {
+			t.Errorf("IsNoData(err)=false, err=%v", err)
+		}
+		if !errors.Is(err, ErrNoData) {
+			t.Errorf("errors.Is(err, ErrNoData)=false, err=%v", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/mdbx/error.go
+++ b/mdbx/error.go
@@ -84,6 +84,12 @@ const minErrno, maxErrno C.int = C.MDBX_KEYEXIST, C.MDBX_LAST_ADDED_ERRCODE
 
 var ErrNotFound = errors.New("key not found")
 
+// ErrNoData is returned when a cursor operation reads the current position of a
+// cursor that is not positioned to any data (a "hollow" cursor), e.g.
+// MDBX_GET_CURRENT on a cursor that was never moved. Distinct from ErrNotFound,
+// which reports that a searched-for key/value does not exist.
+var ErrNoData = errors.New("cursor is not positioned to data")
+
 // App can re-define this messages from init() func
 var CorruptErrorHardwareRecommendations = "Maybe free space is over on disk. Otherwise it's hardware failure. Before creating issue please use tools like https://www.memtest86.com to test RAM and tools like https://www.smartmontools.org to test Disk. To handle hardware risks: use ECC RAM, use RAID of disks, run multiple application instances (or do backups). If hardware checks passed - check FS settings - 'fsync' and 'flock' must be enabled. "
 var CorruptErrorBacktraceRecommendations = "Otherwise - please create issue in Application repo." // with backtrace or coredump. To create coredump set compile option 'MDBX_FORCE_ASSERTIONS=1' and env variable 'GOTRACEBACK=crash'."
@@ -113,6 +119,10 @@ func _operrno(op string, ret int) error {
 // not exist or if the Cursor reached the end of the database without locating
 // a value (EOF).
 func IsNotFound(err error) bool { return err == ErrNotFound } //nolint
+
+// IsNoData returns true if a cursor read (e.g. Cursor.Get with MDBX_GET_CURRENT)
+// hit a cursor that is not positioned to any data. See ErrNoData.
+func IsNoData(err error) bool { return err == ErrNoData } //nolint
 
 func IsKeyExists(err error) bool {
 	return IsErrno(err, KeyExist)

--- a/mdbx/error_unix.go
+++ b/mdbx/error_unix.go
@@ -17,6 +17,9 @@ func operrno(op string, ret C.int) error {
 	if ret == C.MDBX_NOTFOUND {
 		return ErrNotFound
 	}
+	if ret == C.MDBX_ENODATA {
+		return ErrNoData
+	}
 	if minErrno <= ret && ret <= maxErrno {
 		return &OpError{Op: op, Errno: Errno(ret)}
 	}

--- a/mdbx/error_windows.go
+++ b/mdbx/error_windows.go
@@ -14,6 +14,9 @@ func operrno(op string, ret C.int) error {
 	if ret == C.MDBX_NOTFOUND {
 		return ErrNotFound
 	}
+	if ret == C.MDBX_ENODATA {
+		return ErrNoData
+	}
 	if minErrno <= ret && ret <= maxErrno {
 		return &OpError{Op: op, Errno: Errno(ret)}
 	}


### PR DESCRIPTION
## Problem

`GET_CURRENT` on a cursor that was never positioned — a *hollow* cursor, e.g. the surplus cursors `mdbx_cursor_distribute` leaves untouched — returns **`MDBX_ENODATA`**, not `MDBX_NOTFOUND`. These are distinct cursor states in libmdbx (`is_hollow` → `ENODATA`; positioned-past-end → `NOTFOUND`).

`operrno` special-cased only `MDBX_NOTFOUND` (→ `ErrNotFound`). `ENODATA` fell through to the raw branch and became a bare `syscall.Errno`, so:
- `IsNotFound` did not catch it, and there was no way to recognize it;
- callers couldn't tell *"cursor not positioned"* apart from a genuine fault;
- on macOS it surfaced as the confusing `mdbx_cursor_get: no message available on STREAM` (errno 96).

This bit Erigon's `DistributeCursors`, whose `Current()` wrapper only normalizes `ErrNotFound`.

## Fix

Intercept `MDBX_ENODATA` in `operrno` (both `error_unix.go` and `error_windows.go`) and return a new **`ErrNoData`** sentinel, mirroring the existing `MDBX_NOTFOUND → ErrNotFound` path. Add an `IsNoData` helper.

Intercepting the **C constant** is what makes this portable: mdbx.h maps `MDBX_ENODATA` per-OS (`ENODATA` on POSIX, `ERROR_HANDLE_EOF` on Windows), so a Go-side `syscall.ENODATA` comparison would silently miss the Windows case. `ErrNoData` stays distinct from `ErrNotFound` so the library keeps the two cursor states honest; consumers that want to treat both as "no current row" can `|| IsNoData(err)` at their call site.

## Test

`TestCursor_GetCurrent_Hollow` — `GET_CURRENT` on an unpositioned cursor over a non-empty db asserts `IsNoData(err)` and `errors.Is(err, ErrNoData)`. Verified it fails without the `operrno` change (Red: `IsNoData=false … no message available on STREAM`) and passes with it (Green). Full `./mdbx/` package suite green.