### PR TITLE
mdbx: Env.Info(nil) uses NULL txn instead of a throwaway read transaction

### DIFF
--- a/mdbx/env.go
+++ b/mdbx/env.go
@@ -355,6 +355,9 @@ type EnvInfo struct {
 //
 // txn may be nil: mdbx_env_info_ex accepts a NULL transaction and reports
 // the last committed snapshot. Passing a txn pins the report to its snapshot.
+// On an Env that was created but not yet opened, the C API reports success
+// with only geometry/pagesize/maxreaders populated (earlier versions failed
+// because they could not begin the temporary read txn).
 //
 // See mdbx_env_info_ex.
 func (env *Env) Info(txn *Txn) (*EnvInfo, error) {

--- a/mdbx/env.go
+++ b/mdbx/env.go
@@ -353,19 +353,17 @@ type EnvInfo struct {
 
 // Info returns information about the environment.
 //
-// See mdbx_env_info.
-// txn - can be nil
+// txn may be nil: mdbx_env_info_ex accepts a NULL transaction and reports
+// the last committed snapshot. Passing a txn pins the report to its snapshot.
+//
+// See mdbx_env_info_ex.
 func (env *Env) Info(txn *Txn) (*EnvInfo, error) {
-	if txn == nil {
-		var err error
-		txn, err = env.BeginTxn(nil, Readonly)
-		if err != nil {
-			return nil, err
-		}
-		defer txn.Abort()
+	var ctxn *C.MDBX_txn
+	if txn != nil {
+		ctxn = txn._txn
 	}
 	var _info C.MDBX_envinfo
-	ret := C.mdbx_env_info_ex(env._env, txn._txn, &_info, C.size_t(unsafe.Sizeof(_info)))
+	ret := C.mdbx_env_info_ex(env._env, ctxn, &_info, C.size_t(unsafe.Sizeof(_info)))
 	if ret != success {
 		return nil, operrno("mdbx_env_info", ret)
 	}

--- a/mdbx/env.go
+++ b/mdbx/env.go
@@ -356,8 +356,9 @@ type EnvInfo struct {
 // txn may be nil: mdbx_env_info_ex accepts a NULL transaction and reports
 // the last committed snapshot. Passing a txn pins the report to its snapshot.
 // On an Env that was created but not yet opened, the C API reports success
-// with only geometry/pagesize/maxreaders populated (earlier versions failed
-// because they could not begin the temporary read txn).
+// with only a subset of fields populated (geometry, page sizes, and other
+// pre-open state; earlier versions failed because they could not begin the
+// temporary read txn).
 //
 // See mdbx_env_info_ex.
 func (env *Env) Info(txn *Txn) (*EnvInfo, error) {

--- a/mdbx/env.go
+++ b/mdbx/env.go
@@ -365,7 +365,7 @@ func (env *Env) Info(txn *Txn) (*EnvInfo, error) {
 	var _info C.MDBX_envinfo
 	ret := C.mdbx_env_info_ex(env._env, ctxn, &_info, C.size_t(unsafe.Sizeof(_info)))
 	if ret != success {
-		return nil, operrno("mdbx_env_info", ret)
+		return nil, operrno("mdbx_env_info_ex", ret)
 	}
 	return castEnvInfo(_info), nil
 }

--- a/mdbx/env_test.go
+++ b/mdbx/env_test.go
@@ -578,3 +578,37 @@ func TestEnv_CloseDBI(t *testing.T) {
 		t.Errorf("unexpected entries: %d (not %d)", stat.Entries, numdb)
 	}
 }
+
+func TestEnv_Info_NilTxn(t *testing.T) {
+	env, _ := setup(t)
+
+	info, err := env.Info(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.PageSize == 0 {
+		t.Error("PageSize = 0, want nonzero")
+	}
+	if info.MapSize == 0 {
+		t.Error("MapSize = 0, want nonzero")
+	}
+	if info.MaxReaders == 0 {
+		t.Error("MaxReaders = 0, want nonzero")
+	}
+}
+
+func TestEnv_Info_NilTxn_Unopened(t *testing.T) {
+	env, err := NewEnv(Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer env.Close()
+
+	info, err := env.Info(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info == nil {
+		t.Fatal("Info(nil) on unopened env returned nil info")
+	}
+}


### PR DESCRIPTION
`mdbx_env_info_ex` accepts `txn == NULL` (reports the last committed snapshot), so `Info(nil)` no longer begins/aborts a throwaway read txn. Saves 2 cgo calls, a `Txn` alloc, and a reader-slot registration per call, and can no longer fail with `MDBX_READERS_FULL`. Non-nil txn behavior unchanged.
