### PR TITLE
docs: remove stale claims that leaked Txn objects are finalized/aborted by GC

### DIFF
--- a/exp/mdbxpool/put.go
+++ b/exp/mdbxpool/put.go
@@ -4,8 +4,8 @@ package mdbxpool
 
 // Normal (non-race) configuration: Txn objects are returned to the sync.Pool
 // for reuse.  putrace.go flips this constant to false under -race, where
-// Pool.Put randomly drops most objects on the floor: pooled Txns would be
-// lost without ever being terminated and repeated reads would blow the
-// environment's reader limit.  With the constant false the pool aborts Txns
-// eagerly instead of pooling them.
+// Pool.Put randomly drops objects on the floor (and pre-go1.13 race builds
+// never reused them at all): a dropped Txn is never terminated, so repeated
+// reads could exhaust the environment's reader limit.  With the constant
+// false the pool aborts Txns eagerly instead of pooling them.
 const returnTxnToPool = true

--- a/exp/mdbxpool/put.go
+++ b/exp/mdbxpool/put.go
@@ -2,11 +2,9 @@
 
 package mdbxpool
 
-// In general we want Txn objects to be returned to the sync.Pool. But because
-// the default behavior of Pool.Put during race detection is to drop everything
-// on the floor.  This isn't the end of world, but if the Txn finalizers don't
-// don't run fast enough you can end up hitting the environment's limit on
-// readers.  This is still not terrible unless you run your benchmarks with
-// race detection enabled.  In such cases benchmarks issuing repeated reads
-// will quickly blow the environments reader limit.
+// In general we want Txn objects to be returned to the sync.Pool.  But the
+// default behavior of Pool.Put under race detection is to drop everything on
+// the floor; dropped Txns are never terminated and benchmarks issuing
+// repeated reads would quickly blow the environment's reader limit.  So under
+// race detection Txns are aborted eagerly instead of pooled.
 const returnTxnToPool = true

--- a/exp/mdbxpool/put.go
+++ b/exp/mdbxpool/put.go
@@ -4,7 +4,8 @@ package mdbxpool
 
 // Normal (non-race) configuration: Txn objects are returned to the sync.Pool
 // for reuse.  Under -race, putrace.go flips this constant to false: there
-// Pool.Put drops everything on the floor, dropped Txns are never terminated,
-// and repeated reads would blow the environment's reader limit, so Txns are
-// aborted eagerly instead of pooled.
+// Pool.Put drops objects on the floor, so a pooled Txn would be lost without
+// ever being terminated and repeated reads would blow the environment's
+// reader limit.  With the constant false the pool aborts Txns eagerly
+// instead of pooling them.
 const returnTxnToPool = true

--- a/exp/mdbxpool/put.go
+++ b/exp/mdbxpool/put.go
@@ -3,8 +3,8 @@
 package mdbxpool
 
 // Normal (non-race) configuration: Txn objects are returned to the sync.Pool
-// for reuse.  Under -race, putrace.go flips this constant to false: there
-// Pool.Put randomly drops most objects on the floor, so pooled Txns would be
+// for reuse.  putrace.go flips this constant to false under -race, where
+// Pool.Put randomly drops most objects on the floor: pooled Txns would be
 // lost without ever being terminated and repeated reads would blow the
 // environment's reader limit.  With the constant false the pool aborts Txns
 // eagerly instead of pooling them.

--- a/exp/mdbxpool/put.go
+++ b/exp/mdbxpool/put.go
@@ -2,9 +2,9 @@
 
 package mdbxpool
 
-// In general we want Txn objects to be returned to the sync.Pool.  But the
-// default behavior of Pool.Put under race detection is to drop everything on
-// the floor; dropped Txns are never terminated and benchmarks issuing
-// repeated reads would quickly blow the environment's reader limit.  So under
-// race detection Txns are aborted eagerly instead of pooled.
+// Normal (non-race) configuration: Txn objects are returned to the sync.Pool
+// for reuse.  Under -race, putrace.go flips this constant to false: there
+// Pool.Put drops everything on the floor, dropped Txns are never terminated,
+// and repeated reads would blow the environment's reader limit, so Txns are
+// aborted eagerly instead of pooled.
 const returnTxnToPool = true

--- a/exp/mdbxpool/put.go
+++ b/exp/mdbxpool/put.go
@@ -4,8 +4,8 @@ package mdbxpool
 
 // Normal (non-race) configuration: Txn objects are returned to the sync.Pool
 // for reuse.  Under -race, putrace.go flips this constant to false: there
-// Pool.Put drops objects on the floor, so a pooled Txn would be lost without
-// ever being terminated and repeated reads would blow the environment's
-// reader limit.  With the constant false the pool aborts Txns eagerly
-// instead of pooling them.
+// Pool.Put randomly drops most objects on the floor, so pooled Txns would be
+// lost without ever being terminated and repeated reads would blow the
+// environment's reader limit.  With the constant false the pool aborts Txns
+// eagerly instead of pooling them.
 const returnTxnToPool = true

--- a/exp/mdbxpool/put.go
+++ b/exp/mdbxpool/put.go
@@ -5,7 +5,8 @@ package mdbxpool
 // Normal (non-race) configuration: Txn objects are returned to the sync.Pool
 // for reuse.  putrace.go flips this constant to false under -race, where
 // Pool.Put randomly drops objects on the floor (and pre-go1.13 race builds
-// never reused them at all): a dropped Txn is never terminated, so repeated
-// reads could exhaust the environment's reader limit.  With the constant
-// false the pool aborts Txns eagerly instead of pooling them.
+// never reused them at all): a dropped Txn was Reset but never aborted, so
+// its C handle and reader-table slot leak, and enough drops exhaust the
+// environment's reader limit.  With the constant false the pool aborts Txns
+// eagerly instead of pooling them.
 const returnTxnToPool = true

--- a/exp/mdbxpool/putrace.go
+++ b/exp/mdbxpool/putrace.go
@@ -6,7 +6,7 @@ package mdbxpool
 // detection is enabled to prevent benchmarks with race enabled from forcing
 // applications to allow ridiculously large maximum numbers of readers.
 //
-// As of go1.8 the sync.Pool implementation never reuses objects during race
-// detection.  The special logic which bypasses this requires a similar bypass
-// here, unfortunately.
+// Under race detection sync.Pool.Put randomly drops objects on the floor
+// (older Go versions never reused them at all), so pooling cannot be relied
+// on and requires this bypass, unfortunately.
 const returnTxnToPool = false

--- a/exp/mdbxpool/txnpool.go
+++ b/exp/mdbxpool/txnpool.go
@@ -118,26 +118,22 @@ func (p *TxnPool) beginReadonly() (*mdbx.Txn, error) {
 		return p.env.BeginTxn(nil, mdbx.Readonly)
 	}
 
-	// Clear txn.Pooled to let a warning be emitted from the Txn finalizer
-	// again.  And, make sure to clear RawRead to make the Txn appear like it
-	// was just allocated.
+	// Clear txn.Pooled so the Txn appears like it was just allocated.
 	txn.Pooled = false
 
 	return txn, nil
 }
 
 func (p *TxnPool) renewError(err error) {
-	// TODO:
-	// When this is integrated directly in the mdbx package this can use
-	// the same logging functionality that the Txn finalizer uses.
+	// TODO: route this through the mdbx package's logging once integrated
+	// there.
 	log.Printf("mdbxpool: failed to renew transaction: %v", err)
 }
 
 func (p *TxnPool) abortReadonly(txn *mdbx.Txn) {
 	if !returnTxnToPool {
-		// If the pool is disabled from race detection then we just abort the
-		// Txn instead of waiting for the finalizer.  See the files put.go and
-		// putrace.go for more information.
+		// The pool is disabled under race detection; just abort the Txn.
+		// See put.go and putrace.go for more information.
 		txn.Abort()
 		return
 	}
@@ -158,9 +154,7 @@ func (p *TxnPool) abortReadonly(txn *mdbx.Txn) {
 		}
 	}
 
-	// Don't waste cycles resetting RawRead here -- the cost be paid when the
-	// Txn is reused (if at all).  All we need to do is set txn.Pooled to avoid
-	// any warning emitted from the Txn finalizer.
+	// All we need to do is set txn.Pooled before parking the Txn in the pool.
 	txn.Pooled = true
 	txn.Reset()
 	p.pool.Put(txn)

--- a/exp/mdbxpool/txnpool.go
+++ b/exp/mdbxpool/txnpool.go
@@ -16,8 +16,8 @@ import (
 //
 // The zero-value of UpdateHandling causes a TxnPool to ignore all updates;
 // clearing stale readers is then the application's responsibility (pulling
-// an mdbx.Readonly transaction out of the pool releases its stale pages;
-// mdbx installs no Txn finalizers).
+// an mdbx.Readonly transaction out of the pool renews it, which should
+// release its stale pages; mdbx installs no Txn finalizers).
 type UpdateHandling uint
 
 const (

--- a/exp/mdbxpool/txnpool.go
+++ b/exp/mdbxpool/txnpool.go
@@ -14,10 +14,10 @@ import (
 // rate of large updates may need to choose non-default settings to reduce
 // their storage requirements at the cost of read throughput.
 //
-// The zero-value of UpdateHandling causes a TxnPool to ignore all updates and
-// defers to the application and the mdbx.Txn finalizers clear stale readers
-// (pulling an mdbx.Readonly transaction out of the pool is enough to release
-// its stale pages).
+// The zero-value of UpdateHandling causes a TxnPool to ignore all updates;
+// clearing stale readers is then the application's responsibility (pulling
+// an mdbx.Readonly transaction out of the pool releases its stale pages;
+// mdbx installs no Txn finalizers).
 type UpdateHandling uint
 
 const (

--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -147,10 +147,7 @@ func (c *Cursor) Unbind() error {
 	return nil
 }
 
-// Close the cursor handle and free its underlying libmdbx cursor. Unlike
-// LMDB, libmdbx never frees cursors at transaction end, so Close is required
-// for every cursor and is safe before or after its txn ends. No-op if
-// already closed.
+// Close the cursor handle.
 //
 // See mdbx_cursor_close.
 func (c *Cursor) Close() {

--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -147,11 +147,12 @@ func (c *Cursor) Unbind() error {
 	return nil
 }
 
-// Close the cursor handle and clear the finalizer on c.  Cursors belonging to
-// write transactions are closed automatically when the transaction is
-// terminated.
+// Close the cursor handle and free its underlying libmdbx cursor. Unlike
+// LMDB, libmdbx never frees cursors at transaction end, so Close is required
+// for every cursor and is safe before or after its txn ends. No-op if
+// already closed.
 //
-// See mdb_cursor_close.
+// See mdbx_cursor_close.
 func (c *Cursor) Close() {
 	if c._c != nil {
 		if c.txn._txn == nil && !c.txn.readonly {

--- a/mdbx/env.go
+++ b/mdbx/env.go
@@ -216,8 +216,7 @@ func (env *Env) ReaderCheck() (int, error) {
 	return int(r.val), nil
 }
 
-// Close shuts down the environment, releases the memory map, and clears the
-// finalizer on env.
+// Close shuts down the environment and releases the memory map.
 //
 // See mdbx_env_close.
 func (env *Env) Close() {

--- a/mdbx/env.go
+++ b/mdbx/env.go
@@ -138,8 +138,8 @@ type Env struct {
 	_env  *C.MDBX_env
 	label Label
 
-	// closeLock is used to allow the Txn finalizer to check if the Env has
-	// been closed, so that it may know if it must abort.
+	// closeLock allows Txn.abort to check whether the Env has already been
+	// closed, so that it does not touch a freed MDBX_env.
 	closeLock sync.RWMutex
 
 	strictThreadCheck bool

--- a/mdbx/mdbx.go
+++ b/mdbx/mdbx.go
@@ -102,7 +102,7 @@ good idea to periodically call Env.ReaderCheck during application execution.
 However, note that Env.ReaderCheck cannot find readers opened by the
 application itself which have since leaked.  This package installs no Txn
 finalizers: a leaked Txn keeps its reader slot and pins its MVCC snapshot
-until the process exits, so every transaction must be terminated (Env.View
+for the life of the Env, so every transaction must be terminated (Env.View
 and Env.Update do this automatically).
 
 # Caveats

--- a/mdbx/mdbx.go
+++ b/mdbx/mdbx.go
@@ -100,10 +100,10 @@ processes when they start.
 If an application gets accessed by multiple programs concurrently it is also a
 good idea to periodically call Env.ReaderCheck during application execution.
 However, note that Env.ReaderCheck cannot find readers opened by the
-application itself which have since leaked.  Because of this, the lmdb package
-uses a finalizer to abort unreachable Txn objects.  But of course, applications
-must still be careful not to leak unterminated Txn objects in a way such that
-they fail get garbage collected.
+application itself which have since leaked.  This package installs no Txn
+finalizers: a leaked Txn keeps its reader slot and pins its MVCC snapshot
+until the process exits, so every transaction must be terminated (Env.View
+and Env.Update do this automatically).
 
 # Caveats
 

--- a/mdbx/mdbx.go
+++ b/mdbx/mdbx.go
@@ -101,9 +101,10 @@ If an application gets accessed by multiple programs concurrently it is also a
 good idea to periodically call Env.ReaderCheck during application execution.
 However, note that Env.ReaderCheck cannot find readers opened by the
 application itself which have since leaked.  This package installs no Txn
-finalizers: a leaked Txn keeps its reader slot and pins its MVCC snapshot
-for the life of the Env, so every transaction must be terminated (Env.View
-and Env.Update do this automatically).
+finalizers: a leaked read-only Txn keeps its reader slot and pins its MVCC
+snapshot for the life of the Env, and a leaked write Txn holds the exclusive
+writer lock, blocking all further writes.  Every transaction must therefore
+be terminated (Env.View and Env.Update do this automatically).
 
 # Caveats
 

--- a/mdbx/txn.go
+++ b/mdbx/txn.go
@@ -67,10 +67,9 @@ type Txn struct {
 
 	errLogf func(format string, v ...any)
 
-	// Pooled may be set to true while a Txn is stored in a sync.Pool, after
-	// Txn.Reset reset has been called and before Txn.Renew.  This will keep
-	// the Txn finalizer from unnecessarily warning the application about
-	// finalizations.
+	// Pooled may be set to true while a Txn is stored in a sync.Pool.  Kept
+	// for lmdb-go/mdbxpool compatibility; this package has no Txn finalizer,
+	// so the flag has no effect.
 	Pooled bool
 
 	managed  bool
@@ -183,8 +182,8 @@ func (txn *Txn) runOp(fn TxnOp) error {
 	return fn(txn)
 }
 
-// Commit persists all transaction operations to the database and clears the
-// finalizer on txn.  A Txn cannot be used again after Commit is called.
+// Commit persists all transaction operations to the database.  A Txn cannot
+// be used again after Commit is called.
 //
 // See mdbx_txn_commit.
 func (txn *Txn) Commit() (CommitLatency, error) {
@@ -295,8 +294,8 @@ func buildCommitLatency(lat *C.MDBX_commit_latency) CommitLatency {
 	}
 }
 
-// Abort discards pending writes in the transaction and clears the finalizer on
-// txn.  A Txn cannot be used again after Abort is called.
+// Abort discards pending writes in the transaction.  A Txn cannot be used
+// again after Abort is called.
 //
 // See mdbx_txn_abort.
 func (txn *Txn) Abort() {


### PR DESCRIPTION
Docs claimed *"the lmdb package uses a finalizer to abort unreachable Txn objects"* — this fork has no `SetFinalizer` anywhere, so a leaked `Txn` pins its reader slot and MVCC snapshot until process exit. Relying on the promised GC cleanup grows the DB without bound.

Fixes the package doc, `Txn.Pooled`/`Commit`/`Abort`/`closeLock` comments, and the mdbxpool doc making the same claim. Docs only. (Restoring lmdb-go's finalizer is a separate discussion.)
