### PR TITLE
ci: run erigon's make test-short against every PR

### DIFF
--- a/.github/workflows/erigon.yml
+++ b/.github/workflows/erigon.yml
@@ -1,0 +1,40 @@
+name: Erigon
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: erigon-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test-short:
+    name: erigon make test-short
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout mdbx-go
+        uses: actions/checkout@v4
+        with:
+          path: mdbx-go
+
+      - name: Checkout erigon (main)
+        uses: actions/checkout@v4
+        with:
+          repository: erigontech/erigon
+          ref: main
+          path: erigon
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: erigon/go.mod
+          cache-dependency-path: erigon/go.sum
+
+      - name: Point erigon at this mdbx-go
+        working-directory: erigon
+        run: go mod edit -replace github.com/erigontech/mdbx-go=../mdbx-go
+
+      - name: make test-short
+        working-directory: erigon
+        run: make test-short

--- a/.github/workflows/erigon.yml
+++ b/.github/workflows/erigon.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: erigon-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -18,13 +21,18 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: mdbx-go
+          persist-credentials: false
 
+      # Tracking erigon@main is intentional: erigon is this module's primary
+      # consumer and the point is catching integration breaks against its
+      # current state; occasional unrelated upstream failures are acceptable.
       - name: Checkout erigon (main)
         uses: actions/checkout@v6
         with:
           repository: erigontech/erigon
           ref: main
           path: erigon
+          persist-credentials: false
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/erigon.yml
+++ b/.github/workflows/erigon.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: erigon-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: erigon-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -15,18 +15,18 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout mdbx-go
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: mdbx-go
 
       - name: Checkout erigon (main)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: erigontech/erigon
           ref: main
           path: erigon
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: erigon/go.mod
           cache-dependency-path: erigon/go.sum


### PR DESCRIPTION
Adds an `Erigon` workflow: checks out `erigontech/erigon@main` next to the PR's mdbx-go, points erigon's `go.mod` at it via a local `replace`, and runs `make test-short` (`-short -failfast`, CL spectest skipped by the target itself).

This turns erigon into an integration test for every mdbx-go PR — API breaks and behavior regressions in the binding surface here before merge instead of at the next erigon dependency bump. Triggers on `pull_request` and `workflow_dispatch`; concurrent runs on the same branch cancel each other; 90-minute cap.

The job runs on this PR itself, so its first result is its own validation.