### PR TITLE
ci: golangci-lint v2.12.2, more linters enabled, findings fixed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,4 +13,4 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: 'v2.11.4'
+          version: 'v2.12.2'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,12 +29,24 @@ linters:
     - makezero
     - perfsprint
     - gocritic
+    - copyloopvar
+    - intrange
+    - misspell
+    - nolintlint
+    - predeclared
+    - usestdlibvars
+    - mirror
+    - exptostd
+    - dupword
+    - gocheckcompilerdirectives
   disable:
+    # errname would rename the long-established public Errno constants
+    # (NotFound, KeyExist, ...) and the Errno type itself.
+    - errname
     - contextcheck
     - err113
     - errchkjson
     - exhaustive
-    - gocheckcompilerdirectives
     - gosec
     - musttag
     - protogetter

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ lint:
 
 lint-deps:
 	rm -f ./build/bin/golangci-lint
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./build/bin v2.1.5
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./build/bin v2.12.2
 
 clean:
 	cd libmdbx && make clean

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ lint:
 
 lint-deps:
 	rm -f ./build/bin/golangci-lint
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./build/bin v2.12.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b ./build/bin v2.12.2
 
 clean:
 	cd libmdbx && make clean

--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -227,8 +227,6 @@ func (c *Cursor) Get(setkey, setval []byte, op uint) (key, val []byte, err error
 // data for reference (Next, First, Last, etc).
 //
 // See mdb_cursor_get.
-//
-//nolint:gocritic // false positive on dupSubExpr
 func (c *Cursor) getValEmpty(op uint) C.mdbxgo_val_result {
 	return C.mdbxgo_cursor_get_empty(c._c, C.MDBX_cursor_op(op))
 }
@@ -237,8 +235,6 @@ func (c *Cursor) getValEmpty(op uint) C.mdbxgo_val_result {
 // reference (GetBoth, GetBothRange, etc).
 //
 // See mdb_cursor_get.
-//
-//nolint:gocritic // false positive on dupSubExpr
 func (c *Cursor) getVal(setkey, setval []byte, op uint) C.mdbxgo_val_result {
 	var k, v *C.char
 	if len(setkey) > 0 {

--- a/mdbx/cursor_test.go
+++ b/mdbx/cursor_test.go
@@ -502,7 +502,7 @@ func TestCursor_Get_DupFixed(t *testing.T) {
 			return err
 		}
 
-		for i := int64(0); i < int64(numitems); i++ {
+		for i := range int64(numitems) {
 			err = txn.Put(dbi, key, []byte(fmt.Sprintf("%016x", i)), 0)
 			if err != nil {
 				return err
@@ -548,7 +548,7 @@ func TestCursor_Get_DupFixed(t *testing.T) {
 				}
 
 				multi := WrapMulti(v, stride)
-				for i := 0; i < multi.Len(); i++ {
+				for i := range multi.Len() {
 					items = append(items, multi.Val(i))
 				}
 			}
@@ -1683,7 +1683,7 @@ func BenchmarkCursor(b *testing.B) {
 		b.ResetTimer()
 		defer b.StopTimer()
 
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			cur, err := txn.OpenCursor(db)
 			if err != nil {
 				return err
@@ -1718,21 +1718,21 @@ func BenchmarkCursor_Renew(b *testing.B) {
 
 	_ = env.View(func(txn *Txn) (err error) {
 		b.Run("1", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				if err := cur.Renew(txn); err != nil {
 					panic(err)
 				}
 			}
 		})
 		b.Run("2", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				if err := cur.Bind(txn, db); err != nil {
 					panic(err)
 				}
 			}
 		})
 		b.Run("3", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				c, err := txn.OpenCursor(db)
 				if err != nil {
 					panic(err)
@@ -1741,7 +1741,7 @@ func BenchmarkCursor_Renew(b *testing.B) {
 			}
 		})
 		b.Run("4", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				cur := CursorFromPool()
 				if err := cur.Bind(txn, db); err != nil {
 					panic(err)
@@ -1782,7 +1782,7 @@ func BenchmarkCursor_Set_OneKey(b *testing.B) {
 		}
 
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_, _, err := c.Get(k, nil, Set)
 			if err != nil {
 				return err
@@ -1827,7 +1827,7 @@ func BenchmarkCursor_Set_Sequence(b *testing.B) {
 			return err
 		}
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for i := range b.N {
 			_, _, err = c.Get(keys[i], nil, Set)
 			if err != nil {
 				return err
@@ -1873,7 +1873,7 @@ func BenchmarkCursor_Set_Random(b *testing.B) {
 			return err
 		}
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for i := range b.N {
 			_, _, err = c.Get(keys[i], nil, Set)
 			if err != nil {
 				return err
@@ -1916,7 +1916,7 @@ func mustOpenDupSortDB(t *testing.T, env *Env, name string) DBI {
 func mustPutUniqueSeq(t *testing.T, env *Env, db DBI, n int) {
 	t.Helper()
 	if err := env.Update(func(txn *Txn) error {
-		for i := 0; i < n; i++ {
+		for i := range n {
 			k := fmt.Sprintf("k%d", i)
 			v := fmt.Sprintf("v%d", i)
 			if err := txn.Put(db, []byte(k), []byte(v), 0); err != nil {

--- a/mdbx/duration_test.go
+++ b/mdbx/duration_test.go
@@ -22,14 +22,14 @@ func assertEqual16dot16(t *testing.T, actual Duration16dot16, expected Duration1
 }
 
 func TestDurationWithDuration(t *testing.T) {
-	for i := 0; i <= 1000; i++ {
+	for i := range 1001 {
 		expected := time.Duration(i) * time.Second
 		assertEqualDuration(t, NewDuration16dot16(expected).ToDuration(), expected)
 	}
 }
 
 func TestDurationWith16dot16(t *testing.T) {
-	for i := 0; i <= 1000; i++ {
+	for i := range 1001 {
 		expected := Duration16dot16(i * 65536)
 		assertEqual16dot16(t, NewDuration16dot16(expected.ToDuration()), expected)
 	}

--- a/mdbx/env.go
+++ b/mdbx/env.go
@@ -209,7 +209,7 @@ func (env *Env) Close() {
 	env.closeLock.Unlock()
 }
 
-// CopyFD copies env to the the file descriptor fd.
+// CopyFD copies env to the file descriptor fd.
 //
 // See mdbx_env_copyfd.
 // func (env *Env) CopyFD(fd uintptr) error {

--- a/mdbx/env_test.go
+++ b/mdbx/env_test.go
@@ -552,7 +552,7 @@ func TestEnv_CloseDBI(t *testing.T) {
 	env, _ := setup(t)
 
 	const numdb = 1000
-	for i := 0; i < numdb; i++ {
+	for i := range numdb {
 		dbname := fmt.Sprintf("db%d", i)
 
 		var dbi DBI

--- a/mdbx/mdbx_test.go
+++ b/mdbx/mdbx_test.go
@@ -125,7 +125,7 @@ func TestTest1(t *testing.T) {
 	var data = map[string]string{}
 	var key string
 	var val string
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		key = fmt.Sprintf("Key-%d", i)
 		val = fmt.Sprintf("Val-%d", i)
 		data[key] = val

--- a/mdbx/range_test.go
+++ b/mdbx/range_test.go
@@ -12,7 +12,7 @@ func mustPutSeqBE(t *testing.T, env *Env, name string, n int) DBI {
 	db := mustOpenUniqueDB(t, env, name)
 	if err := env.Update(func(txn *Txn) error {
 		var kb [4]byte
-		for i := 0; i < n; i++ {
+		for i := range n {
 			binary.BigEndian.PutUint32(kb[:], uint32(i))
 			if err := txn.Put(db, kb[:], kb[:], 0); err != nil {
 				return err

--- a/mdbx/reader_test.go
+++ b/mdbx/reader_test.go
@@ -192,7 +192,7 @@ func setupReaderInfoEnv(t *testing.T) (*Env, DBI) {
 		for i := range value {
 			value[i] = byte(i)
 		}
-		for i := 0; i < 2048; i++ {
+		for i := range 2048 {
 			key := []byte(fmt.Sprintf("key-%04d", i))
 			if err = txn.Put(dbi, key, value, 0); err != nil {
 				return err
@@ -212,7 +212,7 @@ func churnReaderInfoPages(env *Env, dbi DBI) error {
 		for i := range value {
 			value[i] = byte(255 - i)
 		}
-		for i := 0; i < 1024; i++ {
+		for i := range 1024 {
 			key := []byte(fmt.Sprintf("key-%04d", i))
 			if err := txn.Put(dbi, key, value, 0); err != nil {
 				return err

--- a/mdbx/txn_test.go
+++ b/mdbx/txn_test.go
@@ -1059,7 +1059,7 @@ func BenchmarkTxn_abort(b *testing.B) {
 	var e = errors.New("abort")
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = env.Update(func(txn *Txn) error { return e })
 	}
 }
@@ -1081,7 +1081,7 @@ func BenchmarkTxn_commit(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		var k [8]byte
 		binary.BigEndian.PutUint64(k[:], uint64(i))
 		err = env.Update(func(txn *Txn) error {
@@ -1102,7 +1102,7 @@ func BenchmarkTxn_ro(b *testing.B) {
 	env, _ := setup(b)
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		err := env.View(func(txn *Txn) error { return nil })
 		if err != nil {
 			b.Error(err)
@@ -1118,7 +1118,7 @@ func BenchmarkTxn_unmanaged_abort(b *testing.B) {
 	defer runtime.UnlockOSThread()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		txn, err := env.BeginTxn(nil, 0)
 		if err != nil {
 			b.Error(err)
@@ -1135,7 +1135,7 @@ func BenchmarkTxn_unmanaged_commit(b *testing.B) {
 	defer runtime.UnlockOSThread()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		txn, err := env.BeginTxn(nil, 0)
 		if err != nil {
 			b.Error(err)
@@ -1152,7 +1152,7 @@ func BenchmarkTxn_unmanaged_ro(b *testing.B) {
 	// Readonly
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		txn, err := env.BeginTxn(nil, Readonly)
 		if err != nil {
 			b.Error(err)
@@ -1176,7 +1176,7 @@ func BenchmarkTxn_renew(b *testing.B) {
 	defer txn.Abort()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = txn.Reset()
 		err = txn.Renew()
 		if err != nil {
@@ -1207,7 +1207,7 @@ func BenchmarkTxn_Put_append(b *testing.B) {
 
 	b.ResetTimer()
 	err = env.Update(func(txn *Txn) (err error) {
-		for i := 0; i < b.N; i++ {
+		for i := range b.N {
 			var k [8]byte
 			binary.BigEndian.PutUint64(k[:], uint64(i))
 			err = txn.Put(db, k[:], k[:], Append)
@@ -1246,7 +1246,7 @@ func BenchmarkTxn_Put_append_noflag(b *testing.B) {
 
 	err = env.Update(func(txn *Txn) (err error) {
 		var k [8]byte
-		for i := 0; i < b.N; i++ {
+		for i := range b.N {
 			binary.BigEndian.PutUint64(k[:], uint64(i))
 			err = txn.Put(db, k[:], k[:], 0)
 			if err != nil {
@@ -1315,7 +1315,7 @@ func BenchmarkTxn_Get_OneKey(b *testing.B) {
 
 	if err := env.View(func(txn *Txn) (err error) {
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_, err := txn.Get(db, k)
 			if err != nil {
 				return err
@@ -1356,7 +1356,7 @@ func BenchmarkTxn_Get_Sequence(b *testing.B) {
 
 	if err := env.View(func(txn *Txn) (err error) {
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for i := range b.N {
 			_, err := txn.Get(db, keys[i])
 			if err != nil {
 				return err
@@ -1397,7 +1397,7 @@ func BenchmarkTxn_Get_Random(b *testing.B) {
 
 	if err := env.View(func(txn *Txn) (err error) {
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for i := range b.N {
 			_, err := txn.Get(db, keys[i])
 			if err != nil {
 				return err

--- a/mdbx/val.go
+++ b/mdbx/val.go
@@ -65,7 +65,7 @@ func WrapMulti(page []byte, stride int) *Multi {
 func (m *Multi) Vals() [][]byte {
 	n := m.Len()
 	ps := make([][]byte, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		ps[i] = m.Val(i)
 	}
 	return ps

--- a/mdbx/val_test.go
+++ b/mdbx/val_test.go
@@ -45,7 +45,7 @@ func TestMultiVal_panic(t *testing.T) {
 }
 
 func TestVal(t *testing.T) {
-	orig := []byte("hey hey")
+	orig := []byte("hello mdbx")
 	val := wrapVal(orig)
 
 	p := castToBytes(val)


### PR DESCRIPTION
The Makefile's `lint-deps` still pinned golangci-lint **v2.1.5** while CI ran **v2.11.4** — now both use the current **v2.12.2**.

Newly enabled linters: `copyloopvar`, `intrange`, `misspell`, `nolintlint`, `predeclared`, `usestdlibvars`, `mirror`, `exptostd`, `dupword`, `gocheckcompilerdirectives`. `errname` was evaluated and deliberately left disabled (with a comment): it demands renaming the long-established public `Errno` constants (`NotFound`, `KeyExist`, …), which would break every consumer.

Findings fixed to make the run clean (`0 issues`):
- a "the the" doc typo (dupword) and an intentional duplicated test string reworded,
- ~30 test/benchmark loops modernized to Go 1.22 integer-range form (intrange, autofixed via `--fix`),
- two `nolint:gocritic` directives that the Cursor.Get rewrite left unused (nolintlint).

Full test suite passes; `gofmt` clean.