### PR TITLE
build: require Go 1.25, enable another batch of linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - run: make race
 
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - run: go test ./mdbx
       - run: go test ./exp/mdbxpool

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,15 @@ linters:
     - exptostd
     - dupword
     - gocheckcompilerdirectives
+    - thelper
+    - tparallel
+    - nilnil
+    - whitespace
+    - sloglint
+    - canonicalheader
+    - iface
+    - recvcheck
+    - unparam
   disable:
     # errname would rename the long-established public Errno constants
     # (NotFound, KeyExist, ...) and the Errno type itself.
@@ -50,8 +59,6 @@ linters:
     - gosec
     - musttag
     - protogetter
-    - recvcheck
-    - unparam
     - wrapcheck
   settings:
     goconst:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For deeper DB understanding please read through [mdbx.h](https://sourcecraft.dev
 ## Min Requirements
 
 C language Compilers compatible with GCC or CLANG (mingw 10 on windows)
-Golang: 1.24
+Golang: 1.25
 
 ## Packages
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/erigontech/mdbx-go
 
-go 1.24.0
+go 1.25.0
 
 require github.com/ianlancetaylor/cgosymbolizer v0.0.0-20260504013507-f4b012c11129
 

--- a/mdbx/cursor_test.go
+++ b/mdbx/cursor_test.go
@@ -401,7 +401,6 @@ func TestLastDup(t *testing.T) {
 			if i == 2 && string(v) != "value3.1" {
 				panic(1)
 			}
-
 		}
 
 		return nil
@@ -409,7 +408,6 @@ func TestLastDup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 }
 
 func TestCursor_Get_op_Set_bytesBuffer(t *testing.T) {
@@ -695,7 +693,6 @@ func TestCursor_Get_reverse(t *testing.T) {
 //}
 
 func TestCursor_Del(t *testing.T) {
-
 	env, _ := setup(t)
 
 	var db DBI

--- a/mdbx/duration_test.go
+++ b/mdbx/duration_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func assertEqualDuration(t *testing.T, actual time.Duration, expected time.Duration) {
+	t.Helper()
 	diff := actual.Nanoseconds() - expected.Nanoseconds()
 	threshold := int64(time.Millisecond)
 	if (diff > threshold) || (diff < -threshold) {
@@ -14,6 +15,7 @@ func assertEqualDuration(t *testing.T, actual time.Duration, expected time.Durat
 }
 
 func assertEqual16dot16(t *testing.T, actual Duration16dot16, expected Duration16dot16) {
+	t.Helper()
 	diff := int64(actual) - int64(expected)
 	threshold := int64(66)
 	if (diff > threshold) || (diff < -threshold) {

--- a/mdbx/env.go
+++ b/mdbx/env.go
@@ -509,7 +509,6 @@ func (env *Env) GetSyncPeriod() (time.Duration, error) {
 func (env *Env) SetSyncBytes(threshold uint) error {
 	ret := C.mdbx_env_set_syncbytes(env._env, C.size_t(threshold))
 	return operrno("mdbx_env_set_syncbytes", ret)
-
 }
 
 func (env *Env) GetSyncBytes() (uint, error) {

--- a/mdbx/env_test.go
+++ b/mdbx/env_test.go
@@ -98,7 +98,6 @@ func TestEnv_PreOpen(t *testing.T) {
 	}
 
 	fmt.Printf("%#v\n", _info)
-
 }
 
 func TestEnv_FD(t *testing.T) {
@@ -498,34 +497,37 @@ func TestEnv_Sync(t *testing.T) {
 	}
 }
 
-func setup(t testing.TB) (*Env, string) {
-	return setupFlags(t, 0, Default)
+func setup(tb testing.TB) (*Env, string) {
+	tb.Helper()
+	return setupFlags(tb, 0, Default)
 }
 
-func setupWithLabel(t testing.TB, label Label) (*Env, string) {
-	return setupFlags(t, 0, label)
+func setupWithLabel(tb testing.TB, label Label) (*Env, string) {
+	tb.Helper()
+	return setupFlags(tb, 0, label)
 }
 
-func setupFlags(t testing.TB, flags uint, label Label) (env *Env, path string) {
+func setupFlags(tb testing.TB, flags uint, label Label) (env *Env, path string) {
+	tb.Helper()
 	env, err := NewEnv(label)
 	if err != nil {
-		t.Fatalf("env: %s", err)
+		tb.Fatalf("env: %s", err)
 	}
-	path = t.TempDir()
+	path = tb.TempDir()
 	err = env.SetOption(OptMaxDB, 1024)
 	if err != nil {
-		t.Fatalf("setmaxdbs: %v", err)
+		tb.Fatalf("setmaxdbs: %v", err)
 	}
 	const pageSize = 4096
 	err = env.SetGeometry(-1, -1, 256*64*1024*pageSize, -1, -1, pageSize)
 	if err != nil {
-		t.Fatalf("setmaxdbs: %v", err)
+		tb.Fatalf("setmaxdbs: %v", err)
 	}
 	err = env.Open(path, flags, 0664)
 	if err != nil {
-		t.Fatalf("open: %s", err)
+		tb.Fatalf("open: %s", err)
 	}
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		env.Close()
 	})
 	return env, path

--- a/mdbx/error_test.go
+++ b/mdbx/error_test.go
@@ -27,7 +27,6 @@ func BenchmarkErrno_Error(b *testing.B) {
 				b.Fatal("empty message")
 			}
 		}
-
 	}
 }
 func TestErrno(t *testing.T) {


### PR DESCRIPTION
Bumps the minimum Go version to **1.25**: `go.mod` (`go 1.25.0`), the test and lint workflows (`go-version: '1.25'`), and the README requirement line. The erigon CI job already builds with erigon's own 1.25.x toolchain, so this aligns the rest.

Second batch of linters on top of #242: `thelper`, `tparallel`, `nilnil`, `whitespace`, `sloglint`, `canonicalheader`, `iface`, and — promoted out of the disable list — `recvcheck` and `unparam` (both clean on this codebase; tests keep their existing exclusion).

Findings fixed for a `0 issues` run: test helpers now start with `tb.Helper()` and name their `testing.TB` param `tb` (thelper), plus a few stray blank lines (whitespace, autofixed). Full suite passes.