### PR TITLE
backport(v0.40.3.1): fix Cursor.Close leaking the C cursor after a write txn ends

### DIFF
--- a/mdbx/cursor.go
+++ b/mdbx/cursor.go
@@ -147,18 +147,18 @@ func (c *Cursor) Unbind() error {
 	return nil
 }
 
-// Close the cursor handle and clear the finalizer on c.  Cursors belonging to
-// write transactions are closed automatically when the transaction is
-// terminated.
+// Close the cursor handle and free its underlying libmdbx cursor.
 //
-// See mdb_cursor_close.
+// Unlike LMDB, libmdbx never frees a cursor when its transaction ends: the end
+// of a write transaction only marks its cursors reusable, it does not release
+// their memory. Close must therefore always call mdbx_cursor_close (which is
+// safe before or after the transaction ends); the earlier skip-when-write-txn-
+// ended branch leaked the C cursor allocation. No-op if already closed.
+//
+// See mdbx_cursor_close.
 func (c *Cursor) Close() {
 	if c._c != nil {
-		if c.txn._txn == nil && !c.txn.readonly {
-			// the cursor has already been released by MDBX.
-		} else {
-			C.mdbx_cursor_close(c._c)
-		}
+		C.mdbx_cursor_close(c._c)
 		c.txn = nil
 		c._c = nil
 	}

--- a/mdbx/cursor_leak_test.go
+++ b/mdbx/cursor_leak_test.go
@@ -1,0 +1,63 @@
+package mdbx
+
+import (
+	"runtime"
+	"testing"
+)
+
+// Regression: in libmdbx (unlike LMDB) cursors are not freed when their
+// transaction ends, so Close must release the C cursor even after the write
+// transaction has committed/aborted, and must be a safe no-op the second time.
+func TestCursor_CloseAfterWriteTxnCommit(t *testing.T) {
+	env, _ := setup(t)
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	txn, err := env.BeginTxn(nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := txn.OpenRoot(0)
+	if err != nil {
+		txn.Abort()
+		t.Fatal(err)
+	}
+	cur, err := txn.OpenCursor(db)
+	if err != nil {
+		txn.Abort()
+		t.Fatal(err)
+	}
+	if err := cur.Put([]byte("k"), []byte("v"), 0); err != nil {
+		txn.Abort()
+		t.Fatal(err)
+	}
+	if _, err := txn.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	cur.Close()
+	cur.Close()
+}
+
+func TestCursor_CloseAfterWriteTxnAbort(t *testing.T) {
+	env, _ := setup(t)
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	txn, err := env.BeginTxn(nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := txn.OpenRoot(0)
+	if err != nil {
+		txn.Abort()
+		t.Fatal(err)
+	}
+	cur, err := txn.OpenCursor(db)
+	if err != nil {
+		txn.Abort()
+		t.Fatal(err)
+	}
+	txn.Abort()
+	cur.Close()
+	cur.Close()
+}


### PR DESCRIPTION
Backports the **cursor-leak fix** from #229 to the **v0.40.3** release line so consumers pinned there get it without pulling the ~11 unrelated changes now on `master`.

Base branch `release/v0.40.3` is exactly the `v0.40.3` tag; merging this and tagging **v0.40.3.1** matches the existing `v0.39.9.1` patch-release convention (a single fix commit descending from the tag).

### The bug
`Cursor.Close()` skipped `mdbx_cursor_close` when the write transaction had already terminated, on the LMDB-era assumption that libmdbx frees the cursor at txn end. libmdbx does **not** — txn end only marks cursors reusable; `mdbx_cursor_close` is what frees them. So every cursor closed after its write txn ended leaked its C-side allocation (~hundreds of bytes each), an unbounded C-heap leak under cursor-heavy write workloads.

### The fix
`Close()` now always calls `mdbx_cursor_close` (documented-safe before or after txn end). Only the minimal `Close()` change is backported — not the rest of #229 (CursorToPool unbind, nil guards, PutReserve-by-value) — to keep the patch low-risk.

Verified: no code path does `ReleaseAllCursors(false)` + `Close` (no double-free), full test suite + the two new regression tests pass on this line.